### PR TITLE
CLOUD-9: Manually constructed yaml files for app deploymentThese are …

### DIFF
--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/datagrid.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/datagrid.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: datagrid
+  labels:
+    app.kubernetes.io/component: payara-datagrid-service
+spec:
+  type: ClusterIP
+  # Hazelcast DNS discovery needs services without cluster IP, so that all endpoints reside in DNS
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/part-of: $(PROJECT)-$(STAGE)
+    app.kubernetes.io/component: payara-app
+  ports:
+  - port: 6900
+    targetPort: 6900
+    name: hazelcast

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/deployment.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               name: podinfo
       containers:
       - name: micro
-        image: payara/micro:latest
+        image: payara/micro:jdk11
         volumeMounts:
           - mountPath: /opt/payara/deployments
             name: deployments

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/deployment.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/component: payara-app
+    app.kubernetes.io/part-of: $(PROJECT)-$(STAGE)
+    app.kubernetes.io/managed-by: payara-cloud     
+    app.kubernetes.io/version: $(VERSION)
+  annotations:
+    # These annotations define the deployment
+    # Variables like NAME, PROJECT, STAGE are fetched from these
+    payara.cloud/artifact-url: XXX
+    payara.cloud/artifact-version: XXX
+    payara.cloud/project: XXX
+    payara.cloud/stage: XXX
+    payara.cloud/artifact: XXX
+    payara.cloud/domain: 9ba44192900145a88bfb.westeurope.aksapp.io
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: $(NAME)
+      app.kubernetes.io/part-of: $(PROJECT)-$(STAGE)
+      app.kubernetes.io/component: payara-app
+  template:
+    metadata:
+      name: app
+      labels:
+        app.kubernetes.io/name: $(NAME)
+        app.kubernetes.io/instance: $(NAME)
+        app.kubernetes.io/component: payara-app
+        app.kubernetes.io/part-of: $(PROJECT)-$(STAGE)
+        app.kubernetes.io/managed-by: payara-cloud   
+      annotations:
+        payara.cloud/artifact-url: $(URL)
+    spec:
+      initContainers:
+        - name: download-app
+          # This curl image downloads the artifacts from URL in annotation
+          # into deployments volume
+          image: curlimages/curl:latest
+          command:
+            - sh
+          args: ["-c", "cd /deployments && curl -O `cat /podinfo/url`"]
+          volumeMounts:
+            - mountPath: /deployments
+              name: deployments
+            - mountPath: /podinfo
+              name: podinfo
+      containers:
+      - name: micro
+        image: payara/micro:latest
+        volumeMounts:
+          - mountPath: /opt/payara/deployments
+            name: deployments
+        # DNS cluster mode allows for instances of same app cluster themselves without need for Kubernetes API access
+        args: ["--deploymentDir", "/opt/payara/deployments", "--clustermode", "dns:$(DATAGRID_SERVICE):6900"]
+        resources:
+          # Allocate quarter of CPU at rest, allow for use up to 1 CPU.
+          requests:
+            cpu: 250m
+          limits:
+            memory: "512Mi"
+            cpu: "1"
+        ports:
+          - containerPort: 8080
+            name: http
+          - containerPort: 6900
+            name: datagrid
+      volumes:
+        - name: deployments
+          emptyDir: 
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: url
+                # put url from annotation into /podinfo/url
+                fieldRef:
+                  fieldPath: metadata.annotations['payara.cloud/artifact-url']

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/ingress.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/ingress.yaml
@@ -1,0 +1,20 @@
+# this apigroup is available from 1.14 onwards
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+  labels:
+    app.kubernetes.io/component: payara-app-ingress
+    app.kubernetes.io/part-of: $(PROJECT)-$(STAGE)
+    app.kubernetes.io/managed-by: payara-cloud  
+spec:
+  rules:
+  - host: $(PROJECT)-$(STAGE).$(DOMAIN)
+    http:
+      paths:
+      - path: $(PATH)
+        backend:
+          serviceName: service
+          servicePort: 80

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/kustomization.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/kustomization.yaml
@@ -1,0 +1,70 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# This folder is a template for an application.
+# Use this folder as base, and override deployment definition with proper metadata
+configurations:
+    # additional fields to expand vars in
+  - var_fields.yaml
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - datagrid.yaml
+commonLabels:
+  app.kubernetes.io/managed-by: payara-cloud  
+vars:
+  # read vars from deployment's annotations
+  - name: NAME
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/artifact']
+  - name: PROJECT
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/project']
+  - name: STAGE
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/stage']
+  - name: VERSION
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/artifact-version']      
+  - name: URL
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/artifact-url']  
+  - name: DOMAIN
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/domain']  
+  - name: PATH
+    objref:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: app
+    fieldref: 
+      fieldpath: metadata.annotations['payara.cloud/path']      
+  - name: DATAGRID_SERVICE
+    objref:
+        apiVersion: v1
+        name: datagrid       
+        kind: Service 

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/service.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  labels:
+    app.kubernetes.io/component: payara-app-service
+spec:
+  selector:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/part-of: $(PROJECT)-$(STAGE)
+    app.kubernetes.io/component: payara-app
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/var_fields.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/app-base/var_fields.yaml
@@ -1,0 +1,13 @@
+# additional paths to expand vars in
+varReference:
+  - path: spec/template/metadata/annotations
+    kind: Deployment
+  - path: spec/template/metadata/labels
+    kind: Deployment  
+  - path: spec/selector/matchLabels
+    kind: Deployment
+  - path: spec/selector
+    kind: Service     
+  - path: spec/rules/http/paths/path
+    kind: Ingress
+    

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/consumer-app/kustomization.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/consumer-app/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../app-base
+# prefix: project
+namePrefix: micro1-
+# suffix: artifact-stage
+nameSuffix: -consumer-app-test
+patchesStrategicMerge:
+  - update_deployment.yaml
+      
+

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/consumer-app/update_deployment.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/consumer-app/update_deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  annotations:
+    payara.cloud/artifact-url: https://cloud3.blob.core.windows.net/deployment/micro1/consumer-app.war
+    payara.cloud/artifact-version: "1"
+    payara.cloud/project: "micro1"
+    payara.cloud/stage: "test"
+    payara.cloud/artifact: consumer-app
+    payara.cloud/path: /consumer-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: micro
+          env: 
+            # Configure REST client via environment variable
+            - name: FISH_PAYARA_TALK_REPLICATIONTROUBLE_CONTENTAUTHZ_USER_REPLICATION_REPLICATIONAPI_MP_REST_URL
+              value: http://micro1-service-producer-app-test/producer-app/replication

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/producer-app/kustomization.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/producer-app/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../app-base
+# prefix: project
+namePrefix: micro1-
+# suffix: artifact-stage
+nameSuffix: -producer-app-test
+patchesStrategicMerge:
+  - update_deployment.yaml

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/producer-app/update_deployment.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/producer-app/update_deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  annotations:
+    payara.cloud/artifact-url: https://cloud3.blob.core.windows.net/deployment/micro1/producer-app.war
+    payara.cloud/artifact-version: "1"
+    payara.cloud/project: "micro1"
+    payara.cloud/stage: "test"
+    payara.cloud/artifact: producer-app
+    payara.cloud/domain: 9ba44192900145a88bfb.westeurope.aksapp.io
+    payara.cloud/path: /producer-app

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/producer-app/update_deployment.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/producer-app/update_deployment.yaml
@@ -8,5 +8,4 @@ metadata:
     payara.cloud/project: "micro1"
     payara.cloud/stage: "test"
     payara.cloud/artifact: producer-app
-    payara.cloud/domain: 9ba44192900145a88bfb.westeurope.aksapp.io
     payara.cloud/path: /producer-app

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/ui/kustomization.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/ui/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../app-base
+# prefix: project
+namePrefix: micro1-
+# suffix: artifact-stage
+nameSuffix: -ui-test
+patchesStrategicMerge:
+  - update_deployment.yaml

--- a/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/ui/update_deployment.yaml
+++ b/deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1/ui/update_deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  annotations:
+    payara.cloud/artifact-url: https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war
+    payara.cloud/artifact-version: "1"
+    payara.cloud/project: "micro1"
+    payara.cloud/stage: "test"
+    payara.cloud/artifact: ui
+    payara.cloud/path: /


### PR DESCRIPTION
These are kustomize templates that deploy three applications - consumer,
producer and UI from https://github.com/pdudits/data-replication-talk.

To apply:

```
cd deployer/deployment-controller/src/test/k8s/experiment-kustomize/micro1
kubectl create ns micro1-test
kubectl apply -n micro1-test -k producer-app
kubectl apply -n micro1-test -k consumer-app
kubectl apply -n micro1-test -k ui
```

Tested with kubectl 1.14.8, kustomize is bit unstable.
