### PR TITLE
Cloud-24 CLOUD-21 CLOUD-30: Provisioning controller, Integrate Azure storage, Startup-time setup

### DIFF
--- a/deployer/deployment-controller/pom.xml
+++ b/deployer/deployment-controller/pom.xml
@@ -120,6 +120,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -261,6 +268,13 @@
                         </executions>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>run</id>
+            <build>
+                <defaultGoal>toolchains:toolchain payara-micro:run</defaultGoal>
             </build>
         </profile>
     </profiles>

--- a/deployer/deployment-controller/pom.xml
+++ b/deployer/deployment-controller/pom.xml
@@ -50,7 +50,7 @@
     <packaging>war</packaging>
 
     <properties>
-
+        <maven.docker-plugin.version>0.32.0</maven.docker-plugin.version>
     </properties>
 
     <dependencies>
@@ -81,6 +81,13 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <version>4.6.4</version>
+        </dependency>
+
+        <!-- Azure Storage SDK -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-storage</artifactId>
+            <version>8.6.0</version>
         </dependency>
 
         <dependency>
@@ -228,6 +235,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <excludedGroups>fish.payara.cloud.deployer.DockerTest</excludedGroups>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -272,9 +282,72 @@
         </profile>
 
         <profile>
+            <!-- Run locally -->
             <id>run</id>
             <build>
                 <defaultGoal>toolchains:toolchain payara-micro:run</defaultGoal>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- run tests with docker runtime -->
+            <id>test-docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>${maven.docker-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>start-storage-emulator</id>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>mcr.microsoft.com/azure-storage/azurite</name>
+                                            <alias>azurite</alias>
+                                            <run>
+                                                <ports>
+                                                    <port>10000:10000</port>
+                                                </ports>
+                                            </run>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-storage-emulator</id>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>run-docker-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <groups>fish.payara.cloud.deployer.DockerTest</groups>
+                                    <excludedGroups combine.self="override"></excludedGroups>
+                                    <systemProperties>
+                                        <artifactstorage.azure.connectionstring>UseDevelopmentStorage=true;</artifactstorage.azure.connectionstring>
+                                        <artifactstorage.azure.container>deployment</artifactstorage.azure.container>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/deployer/deployment-controller/pom.xml
+++ b/deployer/deployment-controller/pom.xml
@@ -256,26 +256,17 @@
                     <plugin>
                         <groupId>fish.payara.maven.plugins</groupId>
                         <artifactId>payara-micro-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-test-instance</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <javaCommandLineOptions>
-                                        <option>
-                                            <value>-Xdebug</value>
-                                        </option>
-                                        <option>
-                                            <key>-Xrunjdwp:transport</key>
-                                            <value>dt_socket,server=y,suspend=n,address=9009</value>
-                                        </option>
-                                    </javaCommandLineOptions>
-                                </configuration>
-                            </execution>
-                        </executions>
+                        <configuration>
+                            <javaCommandLineOptions>
+                                <option>
+                                    <value>-Xdebug</value>
+                                </option>
+                                <option>
+                                    <key>-Xrunjdwp:transport</key>
+                                    <value>dt_socket,server=y,suspend=n,address=9009</value>
+                                </option>
+                            </javaCommandLineOptions>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -285,7 +276,7 @@
             <!-- Run locally -->
             <id>run</id>
             <build>
-                <defaultGoal>toolchains:toolchain payara-micro:run</defaultGoal>
+                <defaultGoal>package payara-micro:start</defaultGoal>
             </build>
         </profile>
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/DockerTest.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/DockerTest.java
@@ -36,23 +36,10 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.process;
+package fish.payara.cloud.deployer;
 
-import java.io.File;
-import java.util.UUID;
-
-public class ProcessAccessor {
-
-    public static DeploymentProcessState createProcess() {
-        return new DeploymentProcessState(new Namespace("test", "dev"), UUID.randomUUID().toString(), null);
-    }
-
-    public static DeploymentProcessState createProcess(File f) {
-        return new DeploymentProcessState(new Namespace("test", "dev"), f.getName(), f);
-    }
-
-    public static StateChanged makeEvent(DeploymentProcessState process, ChangeKind kind) {
-        process.transition(kind);
-        return new StateChanged(process, kind);
-    }
+/**
+ * Test requiring docker runtime
+ */
+public interface DockerTest {
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/ArtifactStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/ArtifactStorage.java
@@ -38,6 +38,7 @@
 
 package fish.payara.cloud.deployer.artifactstorage;
 
+import fish.payara.cloud.deployer.process.DeploymentProcess;
 import fish.payara.cloud.deployer.process.DeploymentProcessState;
 
 import java.io.File;
@@ -47,4 +48,5 @@ import java.util.concurrent.CompletionStage;
 
 public interface ArtifactStorage {
     URI storeArtifact(DeploymentProcessState deploymentProcess) throws IOException;
+    void deleteArtifact(DeploymentProcessState deploymentProcess) throws IOException;
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/ArtifactStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/ArtifactStorage.java
@@ -36,23 +36,15 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.process;
+package fish.payara.cloud.deployer.artifactstorage;
+
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
 
 import java.io.File;
-import java.util.UUID;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CompletionStage;
 
-public class ProcessAccessor {
-
-    public static DeploymentProcessState createProcess() {
-        return new DeploymentProcessState(new Namespace("test", "dev"), UUID.randomUUID().toString(), null);
-    }
-
-    public static DeploymentProcessState createProcess(File f) {
-        return new DeploymentProcessState(new Namespace("test", "dev"), f.getName(), f);
-    }
-
-    public static StateChanged makeEvent(DeploymentProcessState process, ChangeKind kind) {
-        process.transition(kind);
-        return new StateChanged(process, kind);
-    }
+public interface ArtifactStorage {
+    URI storeArtifact(DeploymentProcessState deploymentProcess) throws IOException;
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorage.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.artifactstorage;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.OperationContext;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobContainerPublicAccessType;
+import com.microsoft.azure.storage.blob.BlobRequestOptions;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+
+@ApplicationScoped
+class AzureBlobStorage implements ArtifactStorage {
+
+    static final String CONFIG_CONNECTIONSTRING = "artifactstorage.azure.connectionstring";
+    static final String CONFIG_CONTAINER = "artifactstorage.azure.container";
+
+    @Inject
+    @ConfigProperty(name= CONFIG_CONNECTIONSTRING)
+    String azureConnectionString;
+
+    @Inject
+    @ConfigProperty(name= CONFIG_CONTAINER)
+    String blobContainer;
+
+    private CloudStorageAccount storageAccount;
+    private CloudBlobContainer container;
+
+    @Override
+    public URI storeArtifact(DeploymentProcessState deploymentProcess) throws IOException {
+        try {
+            var dir = container.getDirectoryReference(deploymentProcess.getNamespace().getProject());
+            var blob = dir.getBlockBlobReference(deploymentProcess.getId()+".war");
+            blob.uploadFromFile(deploymentProcess.getTempLocation().getAbsolutePath());
+            return blob.getUri();
+        } catch (URISyntaxException e) {
+            throw new IOException("The name in deployment process is invalid", e);
+        } catch (StorageException e) {
+            throw new IOException("Storage error", e);
+        }
+    }
+
+    @PostConstruct
+    void initAccount()  {
+        try {
+            storageAccount = CloudStorageAccount.parse(azureConnectionString);
+            var client = storageAccount.createCloudBlobClient();
+            container = client.getContainerReference(blobContainer);
+            // the contents of the blob container will be accessible, so that instances can read deployment artifacts,
+            // but cannot list them.
+            container.createIfNotExists(BlobContainerPublicAccessType.BLOB, new BlobRequestOptions(), new OperationContext());
+        } catch (URISyntaxException | InvalidKeyException | StorageException e) {
+            throw new IllegalArgumentException("Azure Connection not configured properly. Check config artifactstorage.azure.connectionstring", e);
+        }
+    }
+
+
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorage.java
@@ -46,6 +46,7 @@ import com.microsoft.azure.storage.blob.BlobRequestOptions;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import fish.payara.cloud.deployer.process.DeploymentProcess;
 import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.setup.AzureStorage;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.annotation.PostConstruct;
@@ -56,6 +57,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 
+@AzureStorage
 @ApplicationScoped
 class AzureBlobStorage implements ArtifactStorage {
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/TempArtifactStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/TempArtifactStorage.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.artifactstorage;
+
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.setup.MockStorage;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.net.URI;
+
+@MockStorage
+@ApplicationScoped
+public class TempArtifactStorage implements ArtifactStorage {
+    @Override
+    public URI storeArtifact(DeploymentProcessState deploymentProcess) throws IOException {
+        return deploymentProcess.getTempLocation().toURI();
+    }
+
+    @Override
+    public void deleteArtifact(DeploymentProcessState deploymentProcess) throws IOException {
+        deploymentProcess.getTempLocation().delete();
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/InspectionController.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/InspectionController.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
@@ -62,16 +63,15 @@ import java.util.zip.ZipFile;
  *
  * <p>The controller will instantiate all implementations of {@link Inspection} instances in the application,
  * and let them inspect contents of the artifact in single pass.</p>
- *
  */
 @ApplicationScoped
 class InspectionController {
     @Inject
-    @ConfigProperty(name="inspection.timeout", defaultValue="PT5S")
+    @ConfigProperty(name = "inspection.timeout", defaultValue = "PT5S")
     Duration inspectionTimeout;
 
     @Inject
-    ManagedExecutorService executorService;
+    ExecutorService executorService;
 
     @Inject
     DeploymentProcess process;
@@ -96,7 +96,7 @@ class InspectionController {
         process.inspectionStarted(deployment);
         var file = deployment.getTempLocation();
         if (file == null || !file.exists()) {
-            throw new IllegalArgumentException("Deployment does not contain a valid file: "+file);
+            throw new IllegalArgumentException("Deployment does not contain a valid file: " + file);
         }
         try (var zipFile = new ZipFile(file)) {
             var inspectionInstances = instantiateInspections();

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
@@ -147,24 +147,32 @@ public class DeploymentProcess {
     /**
      * Mark that inspection process is finished
      * @param process
+     * @return
      */
-    public void inspectionStarted(DeploymentProcessState process) {
-        updateProcess(process, p -> ChangeKind.INSPECTION_STARTED);
+    public DeploymentProcessState inspectionStarted(DeploymentProcessState process) {
+        return updateProcess(process, p -> p.transition(ChangeKind.INSPECTION_STARTED));
     }
 
     /**
      * Mark that inspection process is finished
      * @param process
+     * @return
      */
-    public void inspectionFinished(DeploymentProcessState process) {
-        updateProcess(process, p -> ChangeKind.INSPECTION_FINISHED);
+    public DeploymentProcessState inspectionFinished(DeploymentProcessState process) {
+        return updateProcess(process, p -> p.transition(ChangeKind.INSPECTION_FINISHED));
     }
 
     /**
      * Mark that configuration process starts
      * @param process
+     * @return
      */
-    public void configurationStarted(DeploymentProcessState process) {
-        updateProcess(process, p -> ChangeKind.CONFIGURATION_STARTED);
+    public DeploymentProcessState configurationStarted(DeploymentProcessState process) {
+        return updateProcess(process, p -> p.transition(ChangeKind.CONFIGURATION_STARTED));
     }
+
+    public DeploymentProcessState provisioningStarted(DeploymentProcessState process) {
+        return updateProcess(process, p -> p.transition(ChangeKind.PROVISION_STARTED));
+    }
+
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
@@ -42,6 +42,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import java.io.File;
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -175,4 +176,11 @@ public class DeploymentProcess {
         return updateProcess(process, p -> p.transition(ChangeKind.PROVISION_STARTED));
     }
 
+    public DeploymentProcessState artifactDeleted(DeploymentProcessState process) {
+        return updateProcess(process, DeploymentProcessState::removePersistentLocation);
+    }
+
+    public DeploymentProcessState artifactStored(DeploymentProcessState process, URI persistentUri) {
+        return updateProcess(process, p -> p.setPersistentLocation(persistentUri));
+    }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
@@ -237,6 +237,11 @@ public class DeploymentProcessState {
         return configurations.stream().filter(c -> c.getKind().equals(kind) && c.getId().equals(id)).findAny();
     }
 
+    ChangeKind transition(ChangeKind target) {
+        version++;
+        return target;
+    }
+
     ChangeKind submitConfigurations(boolean force) {
         boolean allComplete = configurations.stream().allMatch(Configuration::isComplete);
         if (allComplete) {

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
@@ -254,4 +254,16 @@ public class DeploymentProcessState {
             return null;
         }
     }
+
+    ChangeKind removePersistentLocation() {
+        version++;
+        persistentLocation = null;
+        return null; // no event broadcasted
+    }
+
+    ChangeKind setPersistentLocation(URI location) {
+        version++;
+        this.persistentLocation = location;
+        return ChangeKind.ARTIFACT_STORED;
+    }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningController.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningController.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.provisioning;
+
+import fish.payara.cloud.deployer.process.ChangeKind;
+import fish.payara.cloud.deployer.process.DeploymentProcess;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.process.StateChanged;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+import javax.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+class ProvisioningController {
+    @Inject
+    @ConfigProperty(name = "provision.timeout", defaultValue = "PT30S")
+    Duration inactivityTimeout;
+
+    @Inject
+    DeploymentProcess process;
+
+    @Inject
+    ScheduledExecutorService executorService;
+
+    private ConcurrentMap<String,DeploymentInProvisioning> activityMonitor = new ConcurrentHashMap<>();
+
+
+    void startProvisioning(@ObservesAsync @ChangeKind.Filter(ChangeKind.CONFIGURATION_FINISHED) StateChanged event) {
+        // possibly we could do any transformations of the artifact (i. e. embedding configuration) here
+
+        // then store artifact to persistent storage
+
+        // process.artifactStored(event.getProcess, persistentUrl);
+        startMonitoring(event);
+        process.provisioningStarted(event.getProcess());
+    }
+
+    void startMonitoring(StateChanged event) {
+        var id = event.getProcess().getId();
+        activityMonitor.put(id, new DeploymentInProvisioning(event));
+        scheduleMonitor(id, inactivityTimeout);
+    }
+
+    private void checkMonitor(String id) {
+        var monitor = activityMonitor.get(id);
+        if (monitor != null) {
+            var remainingTimeout = monitor.expiresIn(inactivityTimeout);
+            if (remainingTimeout.toMillis() < 10) { // there's some rounding going on
+                cancelProvisioning(id);
+                process.fail(monitor.process, "Provisioning timed out", null);
+                activityMonitor.remove(id);
+            } else {
+                scheduleMonitor(id, remainingTimeout);
+            }
+        }
+    }
+
+    private void scheduleMonitor(String id, Duration remainingTimeout) {
+        executorService.schedule(() -> checkMonitor(id), remainingTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void cancelProvisioning(String id) {
+
+    }
+
+    void monitorProgress(@ObservesAsync StateChanged event) {
+        var id = event.getProcess().getId();
+        var monitor = activityMonitor.get(id);
+        if (monitor != null) {
+            if (!monitor.update(event)) {
+                activityMonitor.remove(id);
+            }
+        }
+    }
+
+    static class DeploymentInProvisioning {
+        private final DeploymentProcessState process;
+        int lastVersion;
+        ChangeKind lastEvent;
+        Instant versionTimestamp;
+
+        DeploymentInProvisioning(StateChanged event) {
+            this.lastEvent = event.getKind();
+            this.lastVersion = event.getAtVersion();
+            this.process = event.getProcess();
+            versionTimestamp = Instant.now();
+        }
+
+        synchronized boolean update(StateChanged event) {
+            if (event.getAtVersion() > lastVersion) {
+                this.lastEvent = event.getKind();
+                this.lastVersion = event.getAtVersion();
+                versionTimestamp = Instant.now();
+            }
+            switch(event.getKind()) {
+                case FAILED:
+                case PROVISION_FINISHED:
+                case CLEANUP_STARTED:
+                    return false; // do not monitor further
+                default:
+                    return true;
+            }
+        }
+
+        Duration inactivityDuration() {
+            return Duration.between(versionTimestamp, Instant.now());
+        }
+
+        Duration expiresIn(Duration inactivityTimeout) {
+            return inactivityTimeout.minus(inactivityDuration());
+        }
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/AzureStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/AzureStorage.java
@@ -36,23 +36,18 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.artifactstorage;
+package fish.payara.cloud.deployer.setup;
 
-import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import javax.enterprise.context.ApplicationScoped;
-import java.io.IOException;
-import java.net.URI;
-
-@ApplicationScoped
-public class TempArtifactStorage implements ArtifactStorage {
-    @Override
-    public URI storeArtifact(DeploymentProcessState deploymentProcess) throws IOException {
-        return deploymentProcess.getTempLocation().toURI();
-    }
-
-    @Override
-    public void deleteArtifact(DeploymentProcessState deploymentProcess) throws IOException {
-        deploymentProcess.getTempLocation().delete();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Stereotype
+@Alternative
+@Target(ElementType.TYPE)
+public @interface AzureStorage {
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/MockStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/MockStorage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.setup;
+
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Stereotype
+@Alternative
+@Target(ElementType.TYPE)
+public @interface MockStorage {
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/SetupExtension.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/SetupExtension.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.setup;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterTypeDiscovery;
+import javax.enterprise.inject.spi.Extension;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class SetupExtension implements Extension {
+    private static final Logger LOGGER = Logger.getLogger(SetupExtension.class.getName());
+
+    private Config config;
+
+    void setup(@Observes AfterTypeDiscovery afterTypeDiscovery) {
+        config = ConfigProvider.getConfig(getClass().getClassLoader());
+        var storage = lookupOption("artifactstorage", StorageSetup.class, StorageSetup.MOCK);
+
+        LOGGER.info("Selected artifact storage "+storage);
+        afterTypeDiscovery.getAlternatives().add(storage.alternative);
+
+
+    }
+
+    private <T extends Enum<T>> T lookupOption(String propertyName, Class<T> enumType, T defaultValue) {
+        return config.getOptionalValue(propertyName, String.class)
+                .flatMap(value -> safeConvert(propertyName, value, enumType))
+                .orElse(defaultValue);
+    }
+
+    private <T extends Enum<T>> Optional<T> safeConvert(String propertyName, String value, Class<T> enumType) {
+        try {
+            return Optional.of(Enum.valueOf(enumType, value.toUpperCase()));
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "Invalid value of property "+propertyName+" ["+value+"]. Will fallback to default");
+        }
+        return Optional.empty();
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/StorageSetup.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/StorageSetup.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.setup;
+
+import java.lang.annotation.Annotation;
+
+public enum StorageSetup {
+    AZURE(AzureStorage.class),
+    MOCK(MockStorage.class);
+
+    final Class<?> alternative;
+
+    StorageSetup(Class<? extends Annotation> alternative) {
+        this.alternative = alternative;
+    }
+}

--- a/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
+++ b/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#  The contents of this file are subject to the terms of either the GNU
+#  General Public License Version 2 only ("GPL") or the Common Development
+#  and Distribution License("CDDL") (collectively, the "License").  You
+#  may not use this file except in compliance with the License.  You can
+#  obtain a copy of the License at
+#  https://github.com/payara/Payara/blob/master/LICENSE.txt
+#  See the License for the specific
+#  language governing permissions and limitations under the License.
+#
+#  When distributing the software, include this License Header Notice in each
+#  file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#  GPL Classpath Exception:
+#  The Payara Foundation designates this particular file as subject to the "Classpath"
+#  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#  file that accompanied this code.
+#
+#  Modifications:
+#  If applicable, add the following below the License Header, with the fields
+#  enclosed by brackets [] replaced by your own identifying information:
+#  "Portions Copyright [year] [name of copyright owner]"
+#
+#  Contributor(s):
+#  If you wish your version of this file to be governed by only the CDDL or
+#  only the GPL Version 2, indicate your decision by adding "[Contributor]
+#  elects to include this software in this distribution under the [CDDL or GPL
+#  Version 2] license."  If you don't indicate a single choice of license, a
+#  recipient has the option to distribute your version of this file under
+#  either the CDDL, the GPL Version 2 or to extend the choice of license to
+#  its licensees as provided above.  However, if you add GPL Version 2 code
+#  and therefore, elected the GPL Version 2 license, then the option applies
+#  only if the new code is made subject to such option by the copyright
+#  holder.
+#
+
+# Artifact storage type:
+# Azure - Use Azure blob storage; configure other properties artifactstorage.azure.*
+# Mock - Uses temporary location (for development without real deployment)
+artifactstorage=mock
+
+#artifactstorage=azure
+# Even if following properties are not set, they cannot be commented out, otherwise validation at deployment time fails
+# Access Key to Azure storage account
+artifactstorage.azure.connectionstring=
+# Name of blob container to use. Will be created on first use if it doesn't exist
+artifactstorage.azure.container=

--- a/deployer/deployment-controller/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/deployer/deployment-controller/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+#
+#  The contents of this file are subject to the terms of either the GNU
+#  General Public License Version 2 only ("GPL") or the Common Development
+#  and Distribution License("CDDL") (collectively, the "License").  You
+#  may not use this file except in compliance with the License.  You can
+#  obtain a copy of the License at
+#  https://github.com/payara/Payara/blob/master/LICENSE.txt
+#  See the License for the specific
+#  language governing permissions and limitations under the License.
+#
+#  When distributing the software, include this License Header Notice in each
+#  file and include the License file at glassfish/legal/LICENSE.txt.
+#
+#  GPL Classpath Exception:
+#  The Payara Foundation designates this particular file as subject to the "Classpath"
+#  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#  file that accompanied this code.
+#
+#  Modifications:
+#  If applicable, add the following below the License Header, with the fields
+#  enclosed by brackets [] replaced by your own identifying information:
+#  "Portions Copyright [year] [name of copyright owner]"
+#
+#  Contributor(s):
+#  If you wish your version of this file to be governed by only the CDDL or
+#  only the GPL Version 2, indicate your decision by adding "[Contributor]
+#  elects to include this software in this distribution under the [CDDL or GPL
+#  Version 2] license."  If you don't indicate a single choice of license, a
+#  recipient has the option to distribute your version of this file under
+#  either the CDDL, the GPL Version 2 or to extend the choice of license to
+#  its licensees as provided above.  However, if you add GPL Version 2 code
+#  and therefore, elected the GPL Version 2 license, then the option applies
+#  only if the new code is made subject to such option by the copyright
+#  holder.
+#
+
+fish.payara.cloud.deployer.setup.SetupExtension

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorageConfigIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorageConfigIT.java
@@ -42,6 +42,7 @@ import fish.payara.cloud.deployer.DockerTest;
 import fish.payara.cloud.deployer.process.DeploymentProcessState;
 import fish.payara.cloud.deployer.process.Namespace;
 import fish.payara.cloud.deployer.process.ProcessAccessor;
+import fish.payara.cloud.deployer.setup.SetupExtension;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -52,6 +53,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -74,10 +76,12 @@ public class AzureBlobStorageConfigIT {
                 .addClass(DeploymentProcessState.class)
                 .addClass(Namespace.class)
                 .addClass(ProcessAccessor.class)
+                .addAsServiceProvider(Extension.class, SetupExtension.class)
+                .addPackage(SetupExtension.class.getPackage())
                 .addAsResource(
                         // the properties are defined by the build and available in the client,
                         // but not in the server, which is already running
-                        new StringAsset(passSystemProperties(AzureBlobStorage.CONFIG_CONNECTIONSTRING,
+                        new StringAsset("artifactstorage=Azure\n"+passSystemProperties(AzureBlobStorage.CONFIG_CONNECTIONSTRING,
                                 AzureBlobStorage.CONFIG_CONTAINER)),
                         "META-INF/microprofile-config.properties");
     }
@@ -87,7 +91,7 @@ public class AzureBlobStorageConfigIT {
     }
 
     @Inject
-    AzureBlobStorage storage;
+    ArtifactStorage storage;
 
     @Test
     public void testUpload() throws IOException {

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorageConfigIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorageConfigIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.artifactstorage;
+
+import fish.payara.cloud.deployer.DockerTest;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.process.Namespace;
+import fish.payara.cloud.deployer.process.ProcessAccessor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@Category(DockerTest.class)
+public class AzureBlobStorageConfigIT {
+    @Deployment
+    public static WebArchive deployment() {
+        var shrinkwrap = Maven.resolver().loadPomFromFile("pom.xml").resolve("com.microsoft.azure:azure-storage")
+                .withTransitivity().asFile();
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsLibraries(shrinkwrap)
+                .addClass(ArtifactStorage.class)
+                .addClass(AzureBlobStorage.class)
+                .addClass(DeploymentProcessState.class)
+                .addClass(Namespace.class)
+                .addClass(ProcessAccessor.class)
+                .addAsResource(
+                        // the properties are defined by the build and available in the client,
+                        // but not in the server, which is already running
+                        new StringAsset(passSystemProperties(AzureBlobStorage.CONFIG_CONNECTIONSTRING,
+                                AzureBlobStorage.CONFIG_CONTAINER)),
+                        "META-INF/microprofile-config.properties");
+    }
+
+    static String passSystemProperties(String... properties) {
+        return Stream.of(properties).map(p -> p+"="+System.getProperty(p)).collect(joining("\n"));
+    }
+
+    @Inject
+    AzureBlobStorage storage;
+
+    @Test
+    public void testUpload() throws IOException {
+        var source = new File("pom.xml");
+        var process = ProcessAccessor.createProcess(source);
+        var uri = storage.storeArtifact(process);
+
+        // we should be able to fetch that URI now
+        try (var input = uri.toURL().openStream()) {
+            var content = input.readAllBytes();
+            assertEquals("Downloaded and uploaded sizes should match", source.length(), content.length);
+        }
+    }
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessAccessor.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessAccessor.java
@@ -36,23 +36,18 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.utils;
+package fish.payara.cloud.deployer.process;
 
-import javax.annotation.Resource;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
-import javax.enterprise.inject.Produces;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.UUID;
 
-@Singleton
-public class ManagedConcurrencyProducer {
-    @Resource
-    ManagedScheduledExecutorService mses;
+public class ProcessAccessor {
 
-    @Produces
-    public ManagedScheduledExecutorService produceManagedSchedulerExecutorService() {
-        return mses;
+    public static DeploymentProcessState createProcess() {
+        return new DeploymentProcessState(new Namespace("test", "dev"), UUID.randomUUID().toString(), null);
+    }
+
+    public static StateChanged makeEvent(DeploymentProcessState process, ChangeKind kind) {
+        process.transition(kind);
+        return new StateChanged(process, kind);
     }
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessAccessor.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessAccessor.java
@@ -39,6 +39,7 @@
 package fish.payara.cloud.deployer.process;
 
 import java.io.File;
+import java.net.URI;
 import java.util.UUID;
 
 public class ProcessAccessor {
@@ -52,7 +53,15 @@ public class ProcessAccessor {
     }
 
     public static StateChanged makeEvent(DeploymentProcessState process, ChangeKind kind) {
+        if (kind == null) {
+            return null;
+        }
         process.transition(kind);
         return new StateChanged(process, kind);
     }
+
+    public static StateChanged setPersistentLocation(DeploymentProcessState process, URI location) {
+        return makeEvent(process, process.setPersistentLocation(location));
+    }
+
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessObserver.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessObserver.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertTrue;
@@ -60,10 +61,14 @@ public class ProcessObserver {
     private ConcurrentHashMap<ChangeKind, Integer> eventCounts = new ConcurrentHashMap<>();
     private ConcurrentHashMap<ChangeKind, CountDownLatch> eventLatches = new ConcurrentHashMap<>();
 
+    private static final Logger LOGGER = Logger.getLogger(ProcessObserver.class.getName());
+
     void generalObserver(@ObservesAsync StateChanged event) {
         this.general++;
         this.lastProcess = event.getProcess();
         eventCounts.compute(event.getKind(), ((changeKind, count) -> count == null ? 1 : count+1));
+        var completionMessage = event.getProcess().getCompletionMessage();
+        LOGGER.info(event.getProcess().getId() + " " + event.getKind() + " " + completionMessage != null ? completionMessage : "");
         eventLatches.get(event.getKind()).countDown();
         if (this.latch != null) {
             latch.countDown();

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessObserver.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessObserver.java
@@ -38,6 +38,7 @@
 
 package fish.payara.cloud.deployer.process;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.ObservesAsync;
 import java.util.concurrent.ConcurrentHashMap;
@@ -73,6 +74,7 @@ public class ProcessObserver {
         this.processStart++;
     }
 
+    @PostConstruct
     public void reset() {
         this.general = 0;
         this.processStart = 0;

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionMonitorTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionMonitorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.provisioning;
+
+import fish.payara.cloud.deployer.process.ChangeKind;
+import fish.payara.cloud.deployer.process.DeploymentProcess;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.process.StateChanged;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.verification.VerificationMode;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static fish.payara.cloud.deployer.process.ProcessAccessor.createProcess;
+import static fish.payara.cloud.deployer.process.ProcessAccessor.makeEvent;
+import static org.mockito.Mockito.*;
+
+public class ProvisionMonitorTest {
+
+    ProvisioningController controller;
+    private DeploymentProcessState process;
+    private StateChanged event;
+
+    @Before
+    public void prepareController() {
+        controller = new ProvisioningController();
+        controller.executorService = Executors.newScheduledThreadPool(1);
+        controller.inactivityTimeout = Duration.ofMillis(100);
+        controller.process = mock(DeploymentProcess.class);
+
+        process = createProcess();
+        event = makeEvent(process, ChangeKind.PROVISION_STARTED);
+        controller.startMonitoring(event);
+    }
+
+    @Test
+    public void provisionTimesOutWithoutActivity() {
+        verifyFail(timeout(150));
+    }
+
+    @Test
+    public void activityPostponesTimeout() {
+        var activity = controller.executorService.scheduleAtFixedRate(
+                () -> controller.monitorProgress(makeEvent(process, ChangeKind.POD_CREATED)),
+                25, 50, TimeUnit.MILLISECONDS);
+
+        verifyFail(after(150).never());
+        activity.cancel(true);
+        verifyFail(timeout(150));
+    }
+
+    @Test
+    public void failedCancelsMonitoring() {
+        controller.monitorProgress(makeEvent(process, ChangeKind.FAILED));
+        verifyFail(after(150).never());
+    }
+
+    @Test
+    public void provisionFinishedCancelsMonitoring() {
+        controller.monitorProgress(makeEvent(process, ChangeKind.PROVISION_FINISHED));
+        verifyFail(after(150).never());
+    }
+
+    @Test
+    public void cleanupStartedCancelsMonitoring() {
+        controller.monitorProgress(makeEvent(process, ChangeKind.CLEANUP_STARTED));
+        verifyFail(after(150).never());
+    }
+
+    private void verifyFail(VerificationMode mode) {
+        verify(controller.process, mode).fail(eq(process), any(), any());
+    }
+}


### PR DESCRIPTION
Provisioning Controller uploads the artifact to persistent storage, and expects regular updates to deployment state concerning progress of provision.

Otherwise it declares the process as failed.

Azure Blob store is also integrated into process, the artifacts ready for provision get updated there, and failed deployments get deleted. Feature is tested with emulator, and executed with profile `test-docker`.

Since docker is not always available a fallback is implemented to use not really persistent storage. This extension will be used to select more optional implementations (i. e. Kubernetes vs Nomad vs. Mock)