### PR TITLE
CLOUD-29: Direct provisioning of k8s resources

### DIFF
--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootConfiguration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootConfiguration.java
@@ -45,12 +45,16 @@ import java.util.Set;
 
 public class ContextRootConfiguration extends Configuration {
     public static final String CONTEXT_ROOT = "context-root";
-    public static final String KIND = CONTEXT_ROOT;
-    private final Set<String> KEYS = Set.of(CONTEXT_ROOT);
-    private final String defaultContext;
+    public static final String APP_NAME = "app-name";
 
-    public ContextRootConfiguration(String moduleName, String defaultContext) {
+    public static final String KIND = CONTEXT_ROOT;
+    private final Set<String> KEYS = Set.of(CONTEXT_ROOT, APP_NAME);
+    private final String defaultContext;
+    private final String appName;
+
+    public ContextRootConfiguration(String moduleName, String appName, String defaultContext) {
         super(moduleName);
+        this.appName = appName;
         this.defaultContext = defaultContext;
     }
 
@@ -69,6 +73,8 @@ public class ContextRootConfiguration extends Configuration {
         switch (key) {
             case CONTEXT_ROOT:
                 return Optional.ofNullable(defaultContext);
+            case APP_NAME:
+                return Optional.of(appName);
             default:
                 return super.getDefaultValue(key);
         }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootInspection.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootInspection.java
@@ -111,8 +111,18 @@ class ContextRootInspection implements Inspection {
     @Override
     public void finish(InspectedArtifact artifact) {
         var contextRoot = determineContextRoot(artifact);
-        var config = new ContextRootConfiguration(artifact.getName(), contextRoot);
+        var appName = determineAppName(artifact);
+        var config = new ContextRootConfiguration(artifact.getName(), appName, contextRoot);
         artifact.addConfiguration(config);
+    }
+
+    private String determineAppName(InspectedArtifact artifact) {
+        // use maven artifact id, if exactly one is present
+        if (mavenMetaDiscovered == MavenMetaDiscovered.SINGLE) {
+            return mavenArtifactId;
+        }
+        // use file name without extension otherwise
+        return artifact.getName().replaceFirst("\\.\\w+$","");
     }
 
     private String determineContextRoot(InspectedArtifact artifact) {

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import fish.payara.cloud.deployer.inspection.contextroot.ContextRootConfiguration;
+import fish.payara.cloud.deployer.process.DeploymentProcess;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.provisioning.Provisioner;
+import fish.payara.cloud.deployer.provisioning.ProvisioningException;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.util.logging.Logger;
+
+import static fish.payara.cloud.deployer.kubernetes.Template.fillTemplate;
+
+@ApplicationScoped
+class DirectProvisioner implements Provisioner {
+    public static final Logger LOGGER = Logger.getLogger(DirectProvisioner.class.getName());
+
+    private DefaultKubernetesClient client;
+
+    @Inject
+    @ConfigProperty(name="kubernetes.direct.ingressdomain")
+    String domain;
+
+    @Inject
+    DeploymentProcess process;
+
+    @PostConstruct
+    void connectApiServer() {
+        client = new DefaultKubernetesClient();
+        var version = client.getVersion();
+        LOGGER.info("Successfully connected to API Server version "+version.getMajor()+"."+version.getMinor());
+    }
+
+    public void provision(DeploymentProcessState deployment) throws ProvisioningException {
+        var naming = new Naming(deployment);
+        try {
+            provisionNamespace(naming);
+            provisionDatagrid(naming);
+            provisionService(naming);
+            provisionDeployment(naming);
+            var uri = provisionIngress(naming);
+            process.endpointDetermined(deployment, uri);
+            LOGGER.info("Provisioned " + deployment.getId() + " at "+uri);
+            process.provisioningFinished(deployment);
+        } catch (Exception e) {
+            throw new ProvisioningException("Failed to provision "+deployment.getId(), e);
+        }
+    }
+
+    private URI provisionIngress(Naming naming) throws IOException {
+        naming.createNamespaced("ingress.yaml");
+        // in real world, we should wait until ingress is actually ready by watching its state.
+        return URI.create(String.format("http://%s.%s%s", naming.getNamespace(), domain, naming.getContextRoot()));
+    }
+
+    private void provisionService(Naming naming) throws IOException {
+        naming.createNamespaced("service.yaml");
+    }
+
+    private void provisionDatagrid(Naming naming) throws IOException {
+        naming.createNamespaced("datagrid.yaml");
+    }
+
+    private void provisionDeployment(Naming naming) throws IOException {
+        createFromTemplate(naming.getNamespace(), naming, "deployment.yaml");
+    }
+
+    private void provisionNamespace(Naming n) throws IOException {
+        var serverNamespace = client.namespaces().withName(n.getNamespace()).get();
+        if (serverNamespace == null) {
+            n.createGlobal("namespace.yaml");
+        }
+    }
+
+    private HasMetadata createFromTemplate(String namespace, Naming naming, String template) throws IOException {
+        var resource = fillTemplate(getClass().getResourceAsStream("/kubernetes/templates-direct/"+template), naming::variableValue);
+        var namespacedClient = namespace == null ? client : client.inNamespace(namespace);
+        return namespacedClient.resource((HasMetadata) Serialization.unmarshal(resource, KubernetesResource.class)).createOrReplace();
+    }
+
+    class Naming {
+        DeploymentProcessState deployment;
+        private Naming(DeploymentProcessState deployment) {
+            this.deployment = deployment;
+        }
+
+        private void createNamespaced(String template) throws IOException {
+            createFromTemplate(getNamespace(), this, template);
+        }
+
+        private void createGlobal(String template) throws IOException {
+            createFromTemplate(null, this, template);
+        }
+
+        String getNamespace() {
+            return deployment.getNamespace().getProject()+"-"+deployment.getNamespace().getStage();
+        }
+
+        public String variableValue(String var) {
+            switch(var) {
+                case "ID":
+                    return deployment.getId();
+                case "PROJECT":
+                    return deployment.getNamespace().getProject();
+                case "STAGE":
+                    return deployment.getNamespace().getStage();
+                case "URL":
+                    return deployment.getPersistentLocation().toString();
+                case "NAME":
+                    return deployment.getConfigValue(ContextRootConfiguration.KIND, ContextRootConfiguration.APP_NAME).get();
+                case "DOMAIN":
+                    return domain;
+                case "PATH":
+                    return getContextRoot();
+                case "VERSION":
+                    return "VERSION";
+                default:
+                    throw new IllegalArgumentException("No value provided for variable "+var);
+            }
+        }
+
+        private String getContextRoot() {
+            return deployment.getConfigValue(ContextRootConfiguration.KIND, ContextRootConfiguration.CONTEXT_ROOT).get();
+        }
+    }
+
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
@@ -43,6 +43,7 @@ import fish.payara.cloud.deployer.process.DeploymentProcess;
 import fish.payara.cloud.deployer.process.DeploymentProcessState;
 import fish.payara.cloud.deployer.provisioning.Provisioner;
 import fish.payara.cloud.deployer.provisioning.ProvisioningException;
+import fish.payara.cloud.deployer.setup.DirectProvisioning;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -58,6 +59,7 @@ import java.util.logging.Logger;
 
 import static fish.payara.cloud.deployer.kubernetes.Template.fillTemplate;
 
+@DirectProvisioning
 @ApplicationScoped
 class DirectProvisioner implements Provisioner {
     public static final Logger LOGGER = Logger.getLogger(DirectProvisioner.class.getName());

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
@@ -183,4 +183,12 @@ public class DeploymentProcess {
     public DeploymentProcessState artifactStored(DeploymentProcessState process, URI persistentUri) {
         return updateProcess(process, p -> p.setPersistentLocation(persistentUri));
     }
+
+    public DeploymentProcessState endpointDetermined(DeploymentProcessState process, URI endpoint) {
+        return updateProcess(process, p -> p.setEndpoint(endpoint));
+    }
+
+    public DeploymentProcessState provisioningFinished(DeploymentProcessState process) {
+        return updateProcess(process, p -> p.transition(ChangeKind.PROVISION_FINISHED));
+    }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
@@ -72,6 +72,7 @@ public class DeploymentProcessState {
     private File tempLocation;
     private Set<Configuration> configurations = new LinkedHashSet<>();
     private URI persistentLocation;
+    private URI endpoint;
     private String podName;
     private Instant completion;
 
@@ -265,5 +266,19 @@ public class DeploymentProcessState {
         version++;
         this.persistentLocation = location;
         return ChangeKind.ARTIFACT_STORED;
+    }
+
+    public Optional<String> getConfigValue(String kind, String name, String key) {
+        return findConfiguration(kind, name).flatMap(c -> c.getValue(key));
+    }
+
+    public Optional<String> getConfigValue(String kind, String key) {
+        return getConfigValue(kind, getName(), key);
+    }
+
+    public ChangeKind setEndpoint(URI endpoint) {
+        version++;
+        endpoint = null;
+        return ChangeKind.INGRESS_CREATED;
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/Provisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/Provisioner.java
@@ -36,39 +36,28 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.process;
+package fish.payara.cloud.deployer.provisioning;
 
-import java.io.File;
-import java.net.URI;
-import java.util.UUID;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
 
-public class ProcessAccessor {
-
-    public static DeploymentProcessState createProcess() {
-        return new DeploymentProcessState(new Namespace("test", "dev"), UUID.randomUUID().toString(), null);
-    }
-
-    public static DeploymentProcessState createProcess(File f) {
-        return new DeploymentProcessState(new Namespace("test", "dev"), f.getName(), f);
-    }
-
-    public static StateChanged makeEvent(DeploymentProcessState process, ChangeKind kind) {
-        if (kind == null) {
-            return null;
-        }
-        process.transition(kind);
-        return new StateChanged(process, kind);
-    }
-
-    public static StateChanged setPersistentLocation(DeploymentProcessState process, URI location) {
-        return makeEvent(process, process.setPersistentLocation(location));
-    }
-
-    public static StateChanged addConfiguration(DeploymentProcessState process, Configuration configuration) {
-        return makeEvent(process, process.addConfiguration(configuration));
-    }
-
-    public static DeploymentProcessState createProcessWithName(String name) {
-        return new DeploymentProcessState(new Namespace("test", "dev"), name, null);
-    }
+/**
+ * Provisions application resources for a deployment.
+ *
+ * Provisioner is invoked by Provisioning controller after artifact is uploaded and provisioning is started.
+ * The implementation is responsible for communicating with cloud backend, creating necessary resources and
+ * informing the system about progress of provisioning.
+ *
+ * It should also inform when provisioning is finished and application is available.
+ */
+public interface Provisioner {
+    /**
+     * Provision the deployment. Check for any definition trouble, initiate the provisioning with the backend
+     * and asynchronously update the deployment with information. At the end, invoke
+     * {@link fish.payara.cloud.deployer.process.DeploymentProcess#provisioningFinished(DeploymentProcessState)}
+     * to signal end of provisioning.
+     *
+     * @param deployment deployment to provision
+     * @throws ProvisioningException in case of deployment misconfiguration or backend error
+     */
+    void provision(DeploymentProcessState deployment) throws ProvisioningException;
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningController.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningController.java
@@ -76,6 +76,9 @@ class ProvisioningController {
     @Inject
     ArtifactStorage artifactStorage;
 
+    @Inject
+    Provisioner provisioner;
+
     private ConcurrentMap<String,DeploymentInProvisioning> activityMonitor = new ConcurrentHashMap<>();
 
 
@@ -93,6 +96,13 @@ class ProvisioningController {
 
         startMonitoring(event);
         process.provisioningStarted(event.getProcess());
+
+        try {
+            provisioner.provision(event.getProcess());
+            // provisoning happens asynchronously so it's up to provisioner to mark end of provisioning.
+        } catch (ProvisioningException e) {
+            process.fail(event.getProcess(), "Failed to provision", e);
+        }
     }
 
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningException.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningException.java
@@ -36,39 +36,18 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.process;
+package fish.payara.cloud.deployer.provisioning;
 
-import java.io.File;
-import java.net.URI;
-import java.util.UUID;
-
-public class ProcessAccessor {
-
-    public static DeploymentProcessState createProcess() {
-        return new DeploymentProcessState(new Namespace("test", "dev"), UUID.randomUUID().toString(), null);
+public class ProvisioningException extends Exception {
+    public ProvisioningException(String message) {
+        super(message);
     }
 
-    public static DeploymentProcessState createProcess(File f) {
-        return new DeploymentProcessState(new Namespace("test", "dev"), f.getName(), f);
+    public ProvisioningException(String message, Throwable cause) {
+        super(message, cause);
     }
 
-    public static StateChanged makeEvent(DeploymentProcessState process, ChangeKind kind) {
-        if (kind == null) {
-            return null;
-        }
-        process.transition(kind);
-        return new StateChanged(process, kind);
-    }
-
-    public static StateChanged setPersistentLocation(DeploymentProcessState process, URI location) {
-        return makeEvent(process, process.setPersistentLocation(location));
-    }
-
-    public static StateChanged addConfiguration(DeploymentProcessState process, Configuration configuration) {
-        return makeEvent(process, process.addConfiguration(configuration));
-    }
-
-    public static DeploymentProcessState createProcessWithName(String name) {
-        return new DeploymentProcessState(new Namespace("test", "dev"), name, null);
+    public ProvisioningException(Throwable cause) {
+        super(cause);
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/DirectProvisioning.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/DirectProvisioning.java
@@ -38,47 +38,16 @@
 
 package fish.payara.cloud.deployer.setup;
 
-import fish.payara.cloud.deployer.provisioning.Provisioner;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.AfterTypeDiscovery;
-import javax.enterprise.inject.spi.Extension;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-public class SetupExtension implements Extension {
-    private static final Logger LOGGER = Logger.getLogger(SetupExtension.class.getName());
-
-    private Config config;
-
-    void setup(@Observes AfterTypeDiscovery afterTypeDiscovery) {
-        config = ConfigProvider.getConfig(getClass().getClassLoader());
-        var storage = lookupOption("artifactstorage", StorageSetup.class, StorageSetup.MOCK);
-
-        LOGGER.info("Selected artifact storage "+storage);
-        afterTypeDiscovery.getAlternatives().add(storage.alternative);
-
-        var provisioning = lookupOption("provisioning", ProvisioningSetup.class, ProvisioningSetup.MOCK);
-        LOGGER.info("Selected provisioning kind "+provisioning);
-        afterTypeDiscovery.getAlternatives().add(provisioning.alternative);
-    }
-
-    private <T extends Enum<T>> T lookupOption(String propertyName, Class<T> enumType, T defaultValue) {
-        return config.getOptionalValue(propertyName, String.class)
-                .flatMap(value -> safeConvert(propertyName, value, enumType))
-                .orElse(defaultValue);
-    }
-
-    private <T extends Enum<T>> Optional<T> safeConvert(String propertyName, String value, Class<T> enumType) {
-        try {
-            return Optional.of(Enum.valueOf(enumType, value.toUpperCase()));
-        } catch (RuntimeException e) {
-            LOGGER.log(Level.SEVERE, "Invalid value of property "+propertyName+" ["+value+"]. Will fallback to default");
-        }
-        return Optional.empty();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Stereotype
+@Alternative
+@Target(ElementType.TYPE)
+public @interface DirectProvisioning {
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/MockProvisioning.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/setup/MockProvisioning.java
@@ -38,47 +38,16 @@
 
 package fish.payara.cloud.deployer.setup;
 
-import fish.payara.cloud.deployer.provisioning.Provisioner;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Stereotype;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.AfterTypeDiscovery;
-import javax.enterprise.inject.spi.Extension;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-public class SetupExtension implements Extension {
-    private static final Logger LOGGER = Logger.getLogger(SetupExtension.class.getName());
-
-    private Config config;
-
-    void setup(@Observes AfterTypeDiscovery afterTypeDiscovery) {
-        config = ConfigProvider.getConfig(getClass().getClassLoader());
-        var storage = lookupOption("artifactstorage", StorageSetup.class, StorageSetup.MOCK);
-
-        LOGGER.info("Selected artifact storage "+storage);
-        afterTypeDiscovery.getAlternatives().add(storage.alternative);
-
-        var provisioning = lookupOption("provisioning", ProvisioningSetup.class, ProvisioningSetup.MOCK);
-        LOGGER.info("Selected provisioning kind "+provisioning);
-        afterTypeDiscovery.getAlternatives().add(provisioning.alternative);
-    }
-
-    private <T extends Enum<T>> T lookupOption(String propertyName, Class<T> enumType, T defaultValue) {
-        return config.getOptionalValue(propertyName, String.class)
-                .flatMap(value -> safeConvert(propertyName, value, enumType))
-                .orElse(defaultValue);
-    }
-
-    private <T extends Enum<T>> Optional<T> safeConvert(String propertyName, String value, Class<T> enumType) {
-        try {
-            return Optional.of(Enum.valueOf(enumType, value.toUpperCase()));
-        } catch (RuntimeException e) {
-            LOGGER.log(Level.SEVERE, "Invalid value of property "+propertyName+" ["+value+"]. Will fallback to default");
-        }
-        return Optional.empty();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Stereotype
+@Alternative
+@Target(ElementType.TYPE)
+public @interface MockProvisioning {
 }

--- a/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
+++ b/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
@@ -47,3 +47,7 @@ artifactstorage=mock
 artifactstorage.azure.connectionstring=
 # Name of blob container to use. Will be created on first use if it doesn't exist
 artifactstorage.azure.container=
+
+# Ingress
+# domain name that is handled by ingres
+kubernetes.direct.ingressdomain=9ba44192900145a88bfb.westeurope.aksapp.io

--- a/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
+++ b/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
@@ -48,6 +48,12 @@ artifactstorage.azure.connectionstring=
 # Name of blob container to use. Will be created on first use if it doesn't exist
 artifactstorage.azure.container=
 
+# Provisioning type:
+# Mock - fails the deployment after 5 seconds
+# Direct - directly creates Kubernetes resources, without storing metadata into custom resource
+provisioning=mock
+
+# provisioning=direct
 # Ingress
 # domain name that is handled by ingres
 kubernetes.direct.ingressdomain=9ba44192900145a88bfb.westeurope.aksapp.io

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/datagrid.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/datagrid.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: $(NAME)-datagrid
+  labels:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/component: datagrid
+    app.kubernetes.io/part-of: $(ID)
+    app.kubernetes.io/managed-by: payara-cloud
+spec:
+  type: ClusterIP
+  # Hazelcast DNS discovery needs services without cluster IP, so that all endpoints reside in DNS
+  clusterIP: None
+  selector:
+    app.kubernetes.io/part-of: $(ID)
+    app.kubernetes.io/component: payara-app
+  ports:
+  - port: 6900
+    targetPort: 6900
+    name: hazelcast

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/deployment.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $(NAME)
+  labels:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/component: payara-app
+    app.kubernetes.io/part-of: $(ID)
+    app.kubernetes.io/managed-by: payara-cloud     
+    #app.kubernetes.io/version: $(VERSION)
+  annotations:
+    # These annotations define the deployment
+    # Variables like NAME, PROJECT, STAGE are fetched from these
+    payara.cloud/artifact-url: $(URL)
+    #payara.cloud/artifact-version: XXX
+    payara.cloud/project: $(PROJECT)
+    payara.cloud/stage: $(STAGE)
+    payara.cloud/artifact: $(NAME)
+    payara.cloud/domain: $(DOMAIN)
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: $(NAME)
+      app.kubernetes.io/part-of: $(ID)
+      app.kubernetes.io/component: payara-app
+  template:
+    metadata:
+      name: $(ID)
+      labels:
+        app.kubernetes.io/name: $(NAME)
+        app.kubernetes.io/instance: $(NAME)
+        app.kubernetes.io/component: payara-app
+        app.kubernetes.io/part-of: $(ID)
+        app.kubernetes.io/managed-by: payara-cloud   
+      annotations:
+        payara.cloud/artifact-url: $(URL)
+    spec:
+      initContainers:
+        - name: download-app
+          # This curl image downloads the artifacts from URL in annotation
+          # into deployments volume
+          image: curlimages/curl:latest
+          command:
+            - sh
+          args: ["-c", "cd /deployments && curl -O `cat /podinfo/url`"]
+          volumeMounts:
+            - mountPath: /deployments
+              name: deployments
+            - mountPath: /podinfo
+              name: podinfo
+      containers:
+      - name: micro
+        image: payara/micro:jdk11
+        volumeMounts:
+          - mountPath: /opt/payara/deployments
+            name: deployments
+        # DNS cluster mode allows for instances of same app cluster themselves without need for Kubernetes API access
+        args: ["--deploymentDir", "/opt/payara/deployments", "--clustermode", "dns:$(ID)-datagrid:6900"]
+        resources:
+          # Allocate quarter of CPU at rest, allow for use up to 1 CPU.
+          requests:
+            cpu: 250m
+          limits:
+            memory: "512Mi"
+            cpu: "1"
+        ports:
+          - containerPort: 8080
+            name: http
+          - containerPort: 6900
+            name: datagrid
+      volumes:
+        - name: deployments
+          emptyDir: 
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: url
+                # put url from annotation into /podinfo/url
+                fieldRef:
+                  fieldPath: metadata.annotations['payara.cloud/artifact-url']

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/ingress.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/ingress.yaml
@@ -1,0 +1,21 @@
+# this apigroup is available from 1.14 onwards
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: $(NAME)
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+  labels:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/part-of: $(ID)
+    app.kubernetes.io/managed-by: payara-cloud
+spec:
+  rules:
+  - host: $(PROJECT)-$(STAGE).$(DOMAIN)
+    http:
+      paths:
+      - path: $(PATH)
+        backend:
+          serviceName: $(NAME)
+          servicePort: 80

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/namespace.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $(PROJECT)-$(STAGE)
+  labels:
+    app.kubernetes.io/name: $(STAGE)
+    app.kubernetes.io/component: project-stage
+    app.kubernetes.io/part-of: $(PROJECT)
+    app.kubernetes.io/managed-by: payara-cloud

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/service.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: $(NAME)
+  labels:
+    app.kubernetes.io/name: $(NAME)
+    app.kubernetes.io/component: http
+    app.kubernetes.io/part-of: $(ID)
+    app.kubernetes.io/managed-by: payara-cloud
+spec:
+  selector:
+    app.kubernetes.io/part-of: $(ID)
+    app.kubernetes.io/component: payara-app
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionTimeoutIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionTimeoutIT.java
@@ -64,7 +64,7 @@ public class ProvisionTimeoutIT {
         return ShrinkWrap.create(WebArchive.class)
                 .addPackage(DeploymentProcess.class.getPackage())
                 .addClass(ProcessObserver.class)
-                .addClass(ProvisioningController.class)
+                .addPackage(ProvisioningController.class.getPackage())
                 .addClass(ArtifactStorage.class)
                 .addClass(TempArtifactStorage.class)
                 .addClass(ManagedConcurrencyProducer.class)


### PR DESCRIPTION
Direct provisioner uses simple templating of yaml files (that were tested in #1), and posts the resources to Kubernetes API server configured in running environment (see https://github.com/fabric8io/kubernetes-client#configuring-the-client).

Mock provisioner is provided to enable dev mode.