### PR TITLE
Cloud-31: UI

### DIFF
--- a/deployer/deployment-controller/pom.xml
+++ b/deployer/deployment-controller/pom.xml
@@ -76,12 +76,6 @@
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <version>1.0.6</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -94,6 +88,24 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
             <version>8.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.mvc</groupId>
+            <artifactId>javax.mvc-api</artifactId>
+            <version>1.0.0-RC1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.krazo</groupId>
+            <artifactId>krazo-jersey</artifactId>
+            <version>1.0.0-RC1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.webjars.npm</groupId>
+            <artifactId>unpoly</artifactId>
+            <version>0.61.0</version>
         </dependency>
 
         <dependency>
@@ -126,6 +138,12 @@
             <groupId>fish.payara.arquillian</groupId>
             <artifactId>payara-micro-deployer</artifactId>
             <type>war</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -188,10 +206,6 @@
                                         ${project.build.directory}/dependency/payara-micro-deployer.war
                                     </value>
                                 </option>
-                                 <option>
-                                    <key>--contextroot</key>
-                                    <value>/micro-deployer</value>
-                                </option>
                                 <option>
                                     <key>--contextroot</key>
                                     <value>/micro-deployer</value>
@@ -251,7 +265,7 @@
     <profiles>
         <profile>
             <!-- when debugging integration test, also debug the server -->
-            <id>debug-it</id>
+            <id>debug</id>
             <activation>
                 <property>
                     <name>maven.failsafe.debug</name>
@@ -263,7 +277,7 @@
                         <groupId>fish.payara.maven.plugins</groupId>
                         <artifactId>payara-micro-maven-plugin</artifactId>
                         <configuration>
-                            <javaCommandLineOptions>
+                            <javaCommandLineOptions combine.children="append">
                                 <option>
                                     <value>-Xdebug</value>
                                 </option>
@@ -283,6 +297,52 @@
             <id>run</id>
             <build>
                 <defaultGoal>package payara-micro:start</defaultGoal>
+            </build>
+        </profile>
+
+        <profile>
+            <id>exploded</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <configuration>
+                            <deployWar>false</deployWar>
+                            <commandLineOptions>
+                                <option>
+                                    <key>--deploy</key>
+                                    <value>${project.build.directory}/${project.build.finalName}/</value>
+                                </option>
+                                <option>
+                                    <key>--rootdir</key>
+                                    <value>${project.build.directory}/micro-root</value>
+                                </option>
+                            </commandLineOptions>
+                            <contextRoot>/</contextRoot>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>configured</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <configuration>
+                            <commandLineOptions combine.children="append">
+                                <option>
+                                    <key>--systemproperties</key>
+                                    <value>${user.home}/cloud-deploy.properties</value>
+                                </option>
+                            </commandLineOptions>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorage.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/artifactstorage/AzureBlobStorage.java
@@ -79,7 +79,7 @@ class AzureBlobStorage implements ArtifactStorage {
     public URI storeArtifact(DeploymentProcessState deploymentProcess) throws IOException {
         try {
             var dir = container.getDirectoryReference(deploymentProcess.getNamespace().getProject());
-            var blob = dir.getBlockBlobReference(deploymentProcess.getId()+".war");
+            var blob = dir.getBlockBlobReference(deploymentProcess.getId()+"/"+deploymentProcess.getName());
             blob.uploadFromFile(deploymentProcess.getTempLocation().getAbsolutePath());
             return blob.getUri();
         } catch (URISyntaxException e) {

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/configuration/ConfigurationController.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/configuration/ConfigurationController.java
@@ -45,16 +45,23 @@ import fish.payara.cloud.deployer.process.StateChanged;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.ObservesAsync;
 import javax.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 class ConfigurationController {
     @Inject
     DeploymentProcess deploymentProcess;
+    
+    @Inject @ConfigProperty(name="configuration.autosubmit", defaultValue="false")
+    boolean autoSubmit;
 
     void startConfiguration(@ObservesAsync @ChangeKind.Filter(ChangeKind.INSPECTION_FINISHED) StateChanged event) {
         deploymentProcess.configurationStarted(event.getProcess());
+        
+        if (autoSubmit && event.getProcess().isConfigurationComplete()) {
+            deploymentProcess.submitConfigurations(event.getProcess());
+        }
         // Some tasks that this might do as well:
-        // fast-track option: use defaults, and progress further when there are no required configuration steps
         // place timeout on configuration after which it is submitted
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/MvcModels.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/MvcModels.java
@@ -1,0 +1,31 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package fish.payara.cloud.deployer.endpoints;
+
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Model;
+import javax.enterprise.inject.Produces;
+
+/**
+ *
+ * @author patrik
+ */
+@RequestScoped
+class MvcModels {
+    private DeploymentProcessState deployment;
+
+    @Produces @Model
+    public DeploymentProcessState getDeployment() {
+        return deployment;
+    }
+
+    public void setDeployment(DeploymentProcessState deployment) {
+        this.deployment = deployment;
+    }
+    
+    
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
@@ -193,6 +193,6 @@ public class DeploymentProcess {
     }
 
     public DeploymentProcessState provisioningFinished(DeploymentProcessState process) {
-        return updateProcess(process, p -> p.transition(ChangeKind.PROVISION_FINISHED));
+        return updateProcess(process, p -> p.provisionFinished());
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/MockProvisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/MockProvisioner.java
@@ -55,6 +55,7 @@ class MockProvisioner implements Provisioner {
     @Inject
     ScheduledExecutorService delay;
 
+    @Inject
     @ConfigProperty(name = "provisioning.mock.fail-after", defaultValue = "PT5S")
     Duration failDelay;
 

--- a/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
+++ b/deployer/deployment-controller/src/main/resources/META-INF/microprofile-config.properties
@@ -57,3 +57,7 @@ provisioning=mock
 # Ingress
 # domain name that is handled by ingres
 kubernetes.direct.ingressdomain=9ba44192900145a88bfb.westeurope.aksapp.io
+
+# Configuration
+# Immediately confirm configuration - Skips one click in provisioning, but prevents any optional configuration
+configuration.autosubmit=false

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/faces-config.xml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/faces-config.xml
@@ -37,9 +37,9 @@
   ~  holder.
   -->
 
-<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<faces-config version="2.3" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
-    http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+    http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd">
   
 </faces-config>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/faces-config.xml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,5 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <!--
-  ~ Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~  The contents of this file are subject to the terms of either the GNU
   ~  General Public License Version 2 only ("GPL") or the Common Development
@@ -34,33 +35,11 @@
   ~  and therefore, elected the GPL Version 2 license, then the option applies
   ~  only if the new code is made subject to such option by the copyright
   ~  holder.
--->
+  -->
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <title>Payara Cloud Deploy</title>
-        <meta http-equiv="content-type" content="text/html;charset=utf-8">
-        <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,700&display=swap" rel="stylesheet">
-        <link href="main.css" rel="stylesheet">
-    </head>
-    <body>
-        <header>
-            <h1>Payara Cloud Deploy</h1>
-        </header>
-        <h2>
-            What shall we deploy?
-        </h2>
-        <main>
-            <form enctype="multipart/form-data" action="/api/deployment" method="post">
-                <label for="project">Project</label>
-                <input id="project" name="project" required type="text" pattern="[a-zA-Z0-9-]{4,30}" placeholder="DNS-like name, at least 4 characters (required)">
-                <label for="stage">Stage</label>
-                <input id="stage" name="stage" required type="text" pattern="[a-zA-Z0-9]{1,30}" placeholder="DNS-like name, at least one character">
-                <label for="artifact">Artifact</label>
-                <input type="file" accept=".war" id="artifact" name="artifact">
-                <input type="submit" value="Deploy">
-            </form>
-        </main>
-    </body>
-</html>
+<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+    http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+  
+</faces-config>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  -->
+<ui:composition template="layout.xhtml" xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <ui:define name="main">
+        <h2>Deployment #{deployment.name}</h2>
+        <nav>
+        <h4>Stage: #{deployment.namespace.project}-#{deployment.namespace.stage}</h4>
+        </nav>
+        <main id="status">
+        <c:choose>
+            <c:when test="#{deployment.failed}">
+                <h3>Failed</h3>
+                <p>#{deployment.completionMessage}</p>
+            </c:when>
+            <c:when test="#{deployment.complete and !deployment.failed}">
+                <h3>Success!</h3>
+                <p>#{deployment.completionMessage}</p>
+                <div class="result">
+                    <a href="#{deployment.endpoint}" target="_blank">#{deployment.endpoint}</a>
+                </div>
+            </c:when>
+            <c:when test="#{deployment.configurable}">
+                <p>Configuration pending</p>
+            </c:when>
+            <c:otherwise>
+                <progress/>
+                <p>Deploying...</p>
+            </c:otherwise>
+        </c:choose>
+
+        <p>#{deployment.lastStatusChange} #{deployment.lastChange}</p>
+        <form id="refreshform" up-target="#status" up-cache="false" up-history="false" method="get">
+            <button id="refresh" type="submit">Refresh</button>
+        </form>
+        </main>
+      <script type="text/javascript">
+        //<![CDATA[
+            try {
+                const eventStream = new EventSource(window.location);
+                eventStream.onmessage = (event) => {
+                    if (event.data) {
+                        console.log(event);
+                        const payload = JSON.parse(event.data);
+                        if (payload.complete) {
+                            eventStream.close();
+                        } else {
+                            document.getElementById("refresh").click();
+                        }
+                    }
+                } 
+            } catch(e) {
+                console.log("Could not connect to SSE stream");
+            }
+        //]]>
+     </script>
+    </ui:define>
+</ui:composition>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/layout.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/layout.xhtml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019-2020 Payara Foundation and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~  The contents of this file are subject to the terms of either the GNU
   ~  General Public License Version 2 only ("GPL") or the Common Development
@@ -34,33 +35,34 @@
   ~  and therefore, elected the GPL Version 2 license, then the option applies
   ~  only if the new code is made subject to such option by the copyright
   ~  holder.
--->
+  -->
 
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Payara Cloud Deploy</title>
-        <meta http-equiv="content-type" content="text/html;charset=utf-8">
-        <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,700&display=swap" rel="stylesheet">
-        <link href="main.css" rel="stylesheet">
-    </head>
-    <body>
-        <header>
-            <h1>Payara Cloud Deploy</h1>
-        </header>
-        <h2>
-            What shall we deploy?
-        </h2>
-        <main>
-            <form enctype="multipart/form-data" action="/api/deployment" method="post">
-                <label for="project">Project</label>
-                <input id="project" name="project" required type="text" pattern="[a-zA-Z0-9-]{4,30}" placeholder="DNS-like name, at least 4 characters (required)">
-                <label for="stage">Stage</label>
-                <input id="stage" name="stage" required type="text" pattern="[a-zA-Z0-9]{1,30}" placeholder="DNS-like name, at least one character">
-                <label for="artifact">Artifact</label>
-                <input type="file" accept=".war" id="artifact" name="artifact">
-                <input type="submit" value="Deploy">
-            </form>
-        </main>
-    </body>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+<head>
+    <title>Payara Cloud Deploy</title>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8"/>
+    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,700&amp;display=swap" rel="stylesheet"/>
+    <link href="${request.contextPath}/main.css" rel="stylesheet"/>
+    <link href="${request.contextPath}/webjars/unpoly/0.61.0/dist/unpoly.min.css"/>
+    <script type="text/javascript" defer="defer" src="${request.contextPath}/webjars/unpoly/0.61.0/dist/unpoly.js" onload="initUnpoly()"></script>
+    <script type="text/javascript">//<![CDATA[
+    function initUnpoly() {
+        up.on('up:proxy:load', function(event) {
+            // request html (otherwise chosen by random by server
+            event.request.headers['Accept'] = 'text/html,*/*;q=0.8';
+        });
+    }
+    //]]></script>
+</head>
+<body>
+    <header>
+    <h1><a href="${request.contextPath}/">Payara Cloud Deploy</a></h1>
+    </header>
+    <ui:insert name="main"/>
+
+</body>
 </html>

--- a/deployer/deployment-controller/src/main/webapp/main.css
+++ b/deployer/deployment-controller/src/main/webapp/main.css
@@ -58,8 +58,35 @@ body {
     color: #002c3e;
 }
 
-h1,h2,h3,.primary-orange {
+header, header h1 a, header h1 {
+    background-color: #f0981b;
+    color:  #1b2c3d;
+}
+
+header {
+    border-bottom: 2px solid #ae6e2b
+}
+
+header, h2, div.result {
+    margin: 0;
+    padding: 1rem;
+}
+
+main {
+    margin-top: 2rem;
+}
+
+h1,h2,h3,.primary-orange,h1 a {
     color: #f0981b
+}
+
+h2, div.result {
+    background-color:  #e8eff2;
+    background: linear-gradient(white 40%, #bfd3db)
+}
+
+h1 a {
+    text-decoration: none;
 }
 
 .secondary-blue {
@@ -82,4 +109,10 @@ form {
 }
 input[type=submit] {
     grid-column: main;
+}
+
+progress {
+    display: block;
+    width: 50%;
+    margin: auto;
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/DeploymentObservationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/DeploymentObservationIT.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -93,5 +94,17 @@ public class DeploymentObservationIT {
         assertTrue("Process should be marked as failed", state.isFailed());
         assertNotNull("Process should contain completion time", state.getCompletion());
         assertEquals("PROCESS_STARTED observer should receive an event", 1, observer.getProcessStart());
+    }
+
+    @Test
+    public void provisionedDeploymentIsComplete() {
+        // this will not be allowed for long, but for now we're good with invalid arguments
+        DeploymentProcessState state = process.start(null, null, null);
+        process.provisioningFinished(state);
+        observer.await(ChangeKind.PROVISION_FINISHED);
+        state = observer.getLastProcess();
+        assertTrue("Process should be complete", state.isComplete());
+        assertFalse("Process should not be marked as failed", state.isFailed());
+        assertNotNull("Process should contain completion time", state.getCompletion());
     }
 }


### PR DESCRIPTION
UI utilizes MVC spec using Facelets without JSF as view.
Smooth interaction is handled by means of unpoly libary.

Few new maven profiles added:
* exploded runs Micro with war directory - helps hot replacing view files
* configured runs with additional properties defined in $HOME/cloud-deploy.properties,
  good place for putting keys to the cloud to

Also extended state with useful information for UI and fixed various quirks when tests met real world.