### PR TITLE
Cloud-33: Watch Kubernetes for deployment progress

### DIFF
--- a/deployer/deployment-controller/pom.xml
+++ b/deployer/deployment-controller/pom.xml
@@ -51,6 +51,7 @@
 
     <properties>
         <maven.docker-plugin.version>0.32.0</maven.docker-plugin.version>
+        <fabric8.version>4.6.4</fabric8.version>
     </properties>
 
     <dependencies>
@@ -80,7 +81,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>4.6.4</version>
+            <version>${fabric8.version}</version>
         </dependency>
 
         <!-- Azure Storage SDK -->
@@ -156,6 +157,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <version>${fabric8.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/DeploymentObserver.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/DeploymentObserver.java
@@ -38,6 +38,7 @@
 package fish.payara.cloud.deployer.endpoints;
 
 import fish.payara.cloud.deployer.process.ChangeKind;
+import fish.payara.cloud.deployer.process.LogProduced;
 import fish.payara.cloud.deployer.process.StateChanged;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,7 +82,7 @@ class DeploymentObserver {
         if (broadcaster == null) {
             return;
         }
-        OutboundSseEvent outboundEvent = sse.newEvent(jsonb.toJson(event));
+        OutboundSseEvent outboundEvent = createEvent(event);
         broadcaster.broadcast(outboundEvent);
         if (event.getKind().isTerminal()) {
             broadcasts.get(processID).close();
@@ -89,5 +90,17 @@ class DeploymentObserver {
         }
 
     }
+
+    private OutboundSseEvent createEvent(StateChanged event) {
+        if (event instanceof LogProduced) {
+            return createLogEvent((LogProduced)event);
+        }
+        return sse.newEvent(jsonb.toJson(event));
+    }
+
+    private OutboundSseEvent createLogEvent(LogProduced event) {
+        return sse.newEvent("log", event.getChunk());
+    }
+
 
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/DeploymentResource.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/DeploymentResource.java
@@ -156,7 +156,7 @@ public class DeploymentResource {
         }
         if (state.isComplete()) {
             try (eventSink) {
-                eventSink.send(sse.newEvent(jsonb.toJson(process.getProcessState(id))));
+                eventSink.send(sse.newEvent("state", jsonb.toJson(process.getProcessState(id))));
                 return;
             }
         }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
@@ -84,7 +84,6 @@ class DirectProvisioner implements Provisioner {
             var uri = provisionIngress(naming);
             process.endpointDetermined(deployment, uri);
             LOGGER.info("Provisioned " + deployment.getId() + " at "+uri);
-            process.provisioningFinished(deployment);
         } catch (Exception e) {
             throw new ProvisioningException("Failed to provision "+deployment.getId(), e);
         }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DirectProvisioner.java
@@ -46,11 +46,10 @@ import fish.payara.cloud.deployer.provisioning.ProvisioningException;
 import fish.payara.cloud.deployer.setup.DirectProvisioning;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.io.IOException;
@@ -64,7 +63,8 @@ import static fish.payara.cloud.deployer.kubernetes.Template.fillTemplate;
 class DirectProvisioner implements Provisioner {
     public static final Logger LOGGER = Logger.getLogger(DirectProvisioner.class.getName());
 
-    private DefaultKubernetesClient client;
+    @Inject
+    NamespacedKubernetesClient client;
 
     @Inject
     @ConfigProperty(name="kubernetes.direct.ingressdomain")
@@ -73,12 +73,6 @@ class DirectProvisioner implements Provisioner {
     @Inject
     DeploymentProcess process;
 
-    @PostConstruct
-    void connectApiServer() {
-        client = new DefaultKubernetesClient();
-        var version = client.getVersion();
-        LOGGER.info("Successfully connected to API Server version "+version.getMajor()+"."+version.getMinor());
-    }
 
     public void provision(DeploymentProcessState deployment) throws ProvisioningException {
         var naming = new Naming(deployment);

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/KubernetesClient.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/KubernetesClient.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import fish.payara.cloud.deployer.setup.DirectProvisioning;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+@DirectProvisioning
+public class KubernetesClient {
+    private static final Logger LOGGER = Logger.getLogger(KubernetesClient.class.getName());
+
+    @Produces
+    DefaultKubernetesClient client;
+
+    @PostConstruct
+    void connectApiServer() {
+        client = new DefaultKubernetesClient();
+        var version = client.getVersion();
+        LOGGER.info("Successfully connected to API Server version "+version.getMajor()+"."+version.getMinor());
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/KubernetesWatcher.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/KubernetesWatcher.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import com.google.common.base.Charsets;
+import fish.payara.cloud.deployer.process.ChangeKind;
+import fish.payara.cloud.deployer.process.StateChanged;
+import fish.payara.cloud.deployer.setup.DirectProvisioning;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.kubernetes.client.utils.Serialization;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+@DirectProvisioning
+class KubernetesWatcher {
+    private static final Logger LOGGER = Logger.getLogger(KubernetesWatcher.class.getName());
+
+    @Inject
+    NamespacedKubernetesClient client;
+    @Inject
+    ScheduledExecutorService executorService;
+
+    private Watch ingressWatch;
+    private Watch deploymentWatch;
+    private Watch podWatch;
+    private Set<String> startingPods = new ConcurrentHashMap<String, Boolean>().keySet(true);
+    private ConcurrentMap<String, LogWatch> podWatches = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void startWatching() {
+        ingressWatch = client.inAnyNamespace().extensions().ingresses()
+                .withLabel("app.kubernetes.io/managed-by", "payara-cloud")
+                .watch(new Watcher<Ingress>() {
+                    @Override
+                    public void eventReceived(Action action, Ingress resource) {
+                        ingressEventReceived(action, resource);
+                    }
+
+                    @Override
+                    public void onClose(KubernetesClientException cause) {
+                        LOGGER.log(Level.INFO, "Ingress watch closed", cause);
+                    }
+                });
+        deploymentWatch = client.inAnyNamespace().apps().deployments()
+                .withLabel("app.kubernetes.io/managed-by", "payara-cloud")
+                .watch(new Watcher<Deployment>() {
+                    @Override
+                    public void eventReceived(Action action, Deployment resource) {
+                        deploymentEventReceived(action, resource);
+                    }
+
+                    @Override
+                    public void onClose(KubernetesClientException cause) {
+                        LOGGER.log(Level.INFO, "Deployment watch closed", cause);
+                    }
+                });
+        podWatch = client.inAnyNamespace().pods()
+                .withLabel("app.kubernetes.io/managed-by", "payara-cloud")
+                .watch(new Watcher<Pod>() {
+                    @Override
+                    public void eventReceived(Action action, Pod resource) {
+                        podEventReceived(action, resource);
+                    }
+
+                    @Override
+                    public void onClose(KubernetesClientException cause) {
+                        LOGGER.log(Level.INFO, "Pod watch closed", cause);
+                    }
+                });
+        executorService.scheduleWithFixedDelay(this::pumpPodLogs, 2000, 1000, TimeUnit.MILLISECONDS);
+    }
+
+    @PreDestroy
+    void close() {
+        podWatch.close();
+        deploymentWatch.close();
+        ingressWatch.close();
+        podWatches.values().forEach(LogWatch::close);
+    }
+
+    private void pumpPodLogs() {
+        for (Map.Entry<String, LogWatch> logWatchEntry : podWatches.entrySet()) {
+            var id = logWatchEntry.getKey();
+            var stream = logWatchEntry.getValue().getOutput();
+            try {
+                if (stream.available() > 0) {
+                    byte[] availableBytes = stream.readNBytes(stream.available());
+                    // what will it throw when this is not valid UTF_8 sequence?
+                    String chunk = new String(availableBytes, Charsets.UTF_8);
+                    LOGGER.info("Log for " + id + ":" + chunk);
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to process log pump of " + id, e);
+                unregisterLogWatch(id);
+            }
+        }
+    }
+
+    private boolean becameReady(Watcher.Action action, Pod resource) {
+        var uid = resource.getMetadata().getUid();
+        if (action == Watcher.Action.ADDED) {
+            startingPods.add(uid);
+            return false;
+        } else if (startingPods.contains(uid)) {
+            boolean isReady = resource.getStatus().getContainerStatuses().stream().anyMatch(status -> status.getReady());
+            if (isReady) {
+                startingPods.remove(uid);
+            }
+            return isReady;
+        } else {
+            return false;
+        }
+    }
+
+
+
+    private void podEventReceived(Watcher.Action action, Pod resource) {
+        var id = getDeploymentId(resource);
+        if (id == null) {
+            return;
+        }
+        logEvent(action, resource);
+        if (becameReady(action, resource)) {
+            registerLogWatch(id, resource);
+        }
+
+    }
+
+
+    private void registerLogWatch(String id, Pod resource) {
+        podWatches.computeIfAbsent(id, (i) -> client.pods()
+                .inNamespace(resource.getMetadata().getNamespace())
+                .withName(resource.getMetadata().getName()).watchLog());
+    }
+
+    void unregisterOnSuccess(@ObservesAsync @ChangeKind.Filter(ChangeKind.PROVISION_FINISHED) StateChanged event) {
+        unregisterLogWatch(event.getProcess().getId());
+    }
+
+    private void unregisterLogWatch(String id) {
+        var watch = podWatches.remove(id);
+        watch.close();
+    }
+
+    void unregisterOnFail(@ObservesAsync @ChangeKind.Filter(ChangeKind.FAILED) StateChanged event) {
+        unregisterLogWatch(event.getProcess().getId());
+    }
+
+
+    private void deploymentEventReceived(Watcher.Action action, Deployment resource) {
+        var id = getDeploymentId(resource);
+        if (id == null) {
+            return;
+        }
+        logEvent(action, resource);
+    }
+
+    private String getDeploymentId(HasMetadata resource) {
+        String id = resource.getMetadata().getLabels().get("app.kubernetes.io/part-of");
+        if (id == null) {
+            LOGGER.warning(String.format("Managed %s without deployment id - strange : %s", resource.getKind(), resource));
+            return null;
+        }
+        return id;
+    }
+
+    private void ingressEventReceived(Watcher.Action action, Ingress resource) {
+        var id = getDeploymentId(resource);
+        if (id == null) {
+            return;
+        }
+        logEvent(action, resource);
+    }
+
+    private void logEvent(Watcher.Action action, HasMetadata resource) {
+        LOGGER.info(resource.getKind() + " " + action + "\n" + Serialization.asJson(resource));
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ChangeKind.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ChangeKind.java
@@ -97,9 +97,24 @@ public enum ChangeKind {
     POD_CREATED,
 
     /**
+     * Application container started.
+     */
+    DEPLOYMENT_READY,
+
+    /**
+     * Log output was captured
+     */
+    OUTPUT_LOGGED,
+
+    /**
      * HTTP Mapping was created
      */
     INGRESS_CREATED,
+
+    /**
+     * HTTP Mapping is created
+     */
+    INGRESS_READY,
 
     /**
      * Provisioning finished, process complete.

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ChangeKind.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ChangeKind.java
@@ -139,6 +139,14 @@ public enum ChangeKind {
         return new FilterLiteral(this);
     }
 
+    public boolean isTerminal() {
+        return this == FAILED || this == PROVISION_FINISHED;
+    }
+
+    StateChanged createEvent(DeploymentProcessState state) {
+        return new StateChanged(state, this);
+    }
+
     @Retention(RetentionPolicy.RUNTIME)
     @Qualifier
     public @interface Filter {

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
@@ -74,7 +74,7 @@ public class DeploymentProcess {
 
     DeploymentProcessState start(DeploymentProcessState processState) {
         runningProcesses.put(processState.getId(), processState);
-        processState.fireAsync(deploymentEvent, ChangeKind.PROCESS_STARTED);
+        fireAsync(processState.start());
         return processState;
     }
 
@@ -152,6 +152,10 @@ public class DeploymentProcess {
             storedProcess.fireAsync(deploymentEvent, ChangeKind.PROVISION_FINISHED);
         }
         return storedProcess;
+    }
+
+    CompletionStage<StateChanged> fireAsync(StateChanged changeEvent) {
+        return deploymentEvent.select(changeEvent.getKind().asFilter()).fireAsync(changeEvent);
     }
 
     /**

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessLogOutput.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessLogOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -38,45 +38,16 @@
 
 package fish.payara.cloud.deployer.process;
 
-import javax.json.bind.annotation.JsonbPropertyOrder;
-import javax.json.bind.annotation.JsonbTransient;
-import javax.json.bind.config.PropertyOrderStrategy;
-
 /**
- * Asynchronous event about change of deployment process state.
- * Event is quantified with {@link ChangeKind.Filter} with its {@link ChangeKind.Filter#value() value} equal to {@link #getKind()}
+ * Structured logging of deployment process.
+ * Raw log from app server should be parsed to identify deployment errors and completion of deployment process
  */
-@JsonbPropertyOrder(PropertyOrderStrategy.ANY)
-public class StateChanged {
-    @JsonbTransient
-    private final DeploymentProcessState process;
-    private final ChangeKind kind;
-    private final int atVersion;
+public class DeploymentProcessLogOutput {
 
-    StateChanged(DeploymentProcessState process, ChangeKind kind) {
-        this.process = process;
-        this.kind = kind;
-        this.atVersion = process.getVersion();
-    }
+    private String output;
 
-    public DeploymentProcessState getProcess() {
-        return process;
-    }
-
-    public ChangeKind getKind() {
-        return kind;
-    }
-
-    public int getAtVersion() {
-        return atVersion;
-    }
-
-    public boolean isLastEvent() {
-        return atVersion == process.getVersion();
-    }
-
-    @Override
-    public String toString() {
-        return "StateChanged(id="+getProcess().getId()+", kind="+kind+", atVersion="+atVersion+")";
+    void add(String chunk) {
+        // we'll eventually get to parsing stuff.
+        output = output == null ? chunk : output+chunk;
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/StateChanged.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/StateChanged.java
@@ -67,10 +67,15 @@ public class StateChanged {
         return kind;
     }
 
+    public boolean isTerminal() {
+        return kind.isTerminal();
+    }
+
     public int getAtVersion() {
         return atVersion;
     }
 
+    @JsonbTransient
     public boolean isLastEvent() {
         return atVersion == process.getVersion();
     }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningController.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/ProvisioningController.java
@@ -64,7 +64,7 @@ class ProvisioningController {
     private static final Logger LOGGER = Logger.getLogger(ProvisioningController.class.getName());
 
     @Inject
-    @ConfigProperty(name = "provision.timeout", defaultValue = "PT30S")
+    @ConfigProperty(name = "provisioning.timeout", defaultValue = "PT30S")
     Duration inactivityTimeout;
 
     @Inject
@@ -175,14 +175,7 @@ class ProvisioningController {
                 this.lastVersion = event.getAtVersion();
                 versionTimestamp = Instant.now();
             }
-            switch(event.getKind()) {
-                case FAILED:
-                case PROVISION_FINISHED:
-                case CLEANUP_STARTED:
-                    return false; // do not monitor further
-                default:
-                    return true;
-            }
+            return !event.getKind().isTerminal();
         }
 
         Duration inactivityDuration() {

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/deployment.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           - mountPath: /opt/payara/deployments
             name: deployments
         # DNS cluster mode allows for instances of same app cluster themselves without need for Kubernetes API access
-        args: ["--deploymentDir", "/opt/payara/deployments", "--clustermode", "dns:$(ID)-datagrid:6900"]
+        args: ["--deploymentDir", "/opt/payara/deployments", "--clustermode", "dns:$(NAME)-datagrid:6900"]
         resources:
           # Allocate quarter of CPU at rest, allow for use up to 1 CPU.
           requests:

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
@@ -45,13 +45,13 @@
         <nav>
         <h4>Stage: #{deployment.namespace.project}-#{deployment.namespace.stage}</h4>
         </nav>
-        <main id="status">
+        <main><div id="status">
         <c:choose>
             <c:when test="#{deployment.failed}">
                 <h3>Failed</h3>
                 <p>#{deployment.completionMessage}</p>
             </c:when>
-            <c:when test="#{deployment.complete and !deployment.failed}">
+            <c:when test="#{deployment.ready}">
                 <h3>Success!</h3>
                 <p>#{deployment.completionMessage}</p>
                 <div class="result">
@@ -64,29 +64,46 @@
             <c:otherwise>
                 <progress/>
                 <p>Deploying...</p>
+                <p>#{deployment.lastStatusChange} #{deployment.lastChange}</p>
             </c:otherwise>
         </c:choose>
 
-        <p>#{deployment.lastStatusChange} #{deployment.lastChange}</p>
+        </div>
+
+        <textarea id="log" readonly="readonly" rows="25" style="visibility: hidden">
+
+        </textarea>
+
         <form id="refreshform" up-target="#status" up-cache="false" up-history="false" method="get">
             <button id="refresh" type="submit">Refresh</button>
         </form>
         </main>
+
       <script type="text/javascript">
         //<![CDATA[
             try {
                 const eventStream = new EventSource(window.location);
                 eventStream.onmessage = (event) => {
                     if (event.data) {
+                        // untyped event represent deployment event, let's refresh
                         console.log(event);
-                        const payload = JSON.parse(event.data);
-                        if (payload.complete) {
-                            eventStream.close();
-                        } else {
-                            document.getElementById("refresh").click();
-                        }
+                        document.getElementById("refresh").click();
                     }
-                } 
+                }
+                eventStream.addEventListener("state", (event) => {
+                    console.log("state event",event);
+                    const payload = JSON.parse(event.data);
+                    if (payload.complete) {
+                        eventStream.close();
+                    }
+                })
+                eventStream.addEventListener("log", (event) => {
+                    console.log("log event", event);
+                    const el = document.getElementById('log');
+                    el.style.visibility = "visible";
+                    el.value = el.value+event.data;
+                    el.scrollTop = el.scrollHeight;
+                });
             } catch(e) {
                 console.log("Could not connect to SSE stream");
             }

--- a/deployer/deployment-controller/src/main/webapp/main.css
+++ b/deployer/deployment-controller/src/main/webapp/main.css
@@ -116,3 +116,10 @@ progress {
     width: 50%;
     margin: auto;
 }
+
+#log {
+    width: 100%;
+    background: transparent;
+    color: #0f9;
+    border: 1px solid #f0981b;
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/StoredLog.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/StoredLog.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.mockwebserver.utils.BodyProvider;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.joining;
+
+public class StoredLog {
+    static class Event {
+        Instant timestamp;
+        Duration sinceLastEvent;
+        String action;
+        String payload;
+
+        public Event(Instant timestamp, String action, String payload) {
+            this.timestamp = timestamp;
+            this.action = action;
+            this.payload = payload;
+        }
+
+        String toJson() {
+            return String.format("{\"type\": \"%s\", \"object\":%s}",
+                    action, payload);
+        }
+
+    }
+
+    static class EventStream {
+        private List<Event> stream = new ArrayList<>();
+
+        void add(Instant timestamp, String action, String payload) {
+            stream.add(new Event(timestamp, action, payload));
+        }
+
+        void finish() {
+            Event previous = null;
+            for (Event event : stream) {
+                if (previous != null) {
+                    event.sinceLastEvent = Duration.between(previous.timestamp, event.timestamp);
+                }
+                previous = event;
+            }
+        }
+    }
+
+    private Map<String, EventStream> streams = new HashMap<>();
+
+    private EventStream stream(String key) {
+        return streams.computeIfAbsent(key, (k) -> new EventStream());
+    }
+
+    public boolean hasStream(String id) {
+        return streams.containsKey(id);
+    }
+
+    public List<Event> get(String id) {
+        return hasStream(id) ? streams.get(id).stream : null;
+    }
+
+    public void applyWatchStream(String stream, String path, double speedup, KubernetesServer server) {
+        applyStream(stream, path, speedup, server, Event::toJson);
+    }
+
+    public void applyLogStream(String stream, String path, double speedup, KubernetesServer server) {
+        // Since logs use just simple long poll, there's no way to emulate it with mock server.
+        // we'll send the entire log at once now.
+        var expectation = server.expect().get().withPath(path)
+                .andReturn(200, get(stream).stream().map(e -> e.payload).collect(joining("")))
+                .once();
+    }
+
+    private void applyStream(String stream, String path, double speedup, KubernetesServer server, Function<Event,Object> emitter) {
+        // the internal types are so ugly, that I'm grateful for var :)
+        var expectation = server.expect().withPath(path).andUpgradeToWebSocket().open();
+
+        for (Event event : get(stream)) {
+            if (event.sinceLastEvent == null) {
+                expectation = expectation.immediately().andEmit(emitter.apply(event));
+            } else {
+                expectation = expectation.waitFor((long)(event.sinceLastEvent.toMillis()/speedup))
+                        .andEmit(emitter.apply(event));
+            }
+        }
+        expectation.done().once();
+    }
+
+
+    private void parseFile(Path path) throws IOException {
+        BufferedReader reader = new BufferedReader(new FileReader(path.toFile(), StandardCharsets.UTF_8));
+        while (reader.ready()) {
+            Instant timestamp = Instant.parse(reader.readLine());
+            String kind = reader.readLine();
+            if ("Log".equals(kind)) {
+                String podUid = reader.readLine();
+                int length = Integer.parseInt(reader.readLine());
+                char[] payload = new char[length];
+                reader.read(payload);
+                reader.readLine(); // newline
+                stream(podUid).add(timestamp, null, new String(payload));
+            } else {
+                String objectKind = reader.readLine();
+                String action = reader.readLine();
+                String resource = reader.readLine();
+                stream(objectKind).add(timestamp, action, resource);
+            }
+        }
+        streams.values().stream().forEach(EventStream::finish);
+    }
+
+    static StoredLog parse(Path path) throws IOException {
+        var result = new StoredLog();
+        result.parseFile(path);
+        return result;
+    }
+
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/StoredLogTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/StoredLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -36,47 +36,23 @@
  *  holder.
  */
 
-package fish.payara.cloud.deployer.process;
+package fish.payara.cloud.deployer.kubernetes;
 
-import javax.json.bind.annotation.JsonbPropertyOrder;
-import javax.json.bind.annotation.JsonbTransient;
-import javax.json.bind.config.PropertyOrderStrategy;
+import org.junit.Test;
 
-/**
- * Asynchronous event about change of deployment process state.
- * Event is quantified with {@link ChangeKind.Filter} with its {@link ChangeKind.Filter#value() value} equal to {@link #getKind()}
- */
-@JsonbPropertyOrder(PropertyOrderStrategy.ANY)
-public class StateChanged {
-    @JsonbTransient
-    private final DeploymentProcessState process;
-    private final ChangeKind kind;
-    private final int atVersion;
+import java.io.IOException;
+import java.nio.file.Path;
 
-    StateChanged(DeploymentProcessState process, ChangeKind kind) {
-        this.process = process;
-        this.kind = kind;
-        this.atVersion = process.getVersion();
-    }
+import static org.junit.Assert.assertTrue;
 
-    public DeploymentProcessState getProcess() {
-        return process;
-    }
+public class StoredLogTest {
+    @Test
+    public void readStored() throws IOException {
+        StoredLog log = StoredLog.parse(Path.of("src/test/resources","single-app-1.log"));
 
-    public ChangeKind getKind() {
-        return kind;
-    }
-
-    public int getAtVersion() {
-        return atVersion;
-    }
-
-    public boolean isLastEvent() {
-        return atVersion == process.getVersion();
-    }
-
-    @Override
-    public String toString() {
-        return "StateChanged(id="+getProcess().getId()+", kind="+kind+", atVersion="+atVersion+")";
+        assertTrue(log.hasStream("Deployment"));
+        assertTrue(log.hasStream("Ingress"));
+        assertTrue(log.hasStream("Pod"));
+        assertTrue(log.hasStream("68a78ed6-41da-11ea-95a2-920d8d1d0d91"));
     }
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/WatchTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/WatchTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -87,6 +88,7 @@ public class WatchTest {
             watcher.client = mockServer.getClient();
             watcher.executorService = Executors.newSingleThreadScheduledExecutor();
             watcher.process = deploymentProcess;
+            watcher.pumpInterval = Duration.ofMillis(50);
             watcher.startWatching();
 
             var observer = MockDeploymentProcess.observer();

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/WatchTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/WatchTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import fish.payara.cloud.deployer.process.ChangeKind;
+import fish.payara.cloud.deployer.process.MockDeploymentProcess;
+import fish.payara.cloud.deployer.process.Namespace;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This test is closely bound to how KubernetesWatcher operates.
+ * Capture is created from {@link CreateTestManual#inspectWatches()}, which stores Kubernetes events in a format
+ * understood by {@link StoredLog} and these are then fed into mock kubernetes server
+ */
+public class WatchTest {
+    @Rule
+    public KubernetesServer mockServer = new KubernetesServer();
+
+    @Test
+    public void fromCapture() throws IOException, InterruptedException {
+        var log = StoredLog.parse(Path.of("src/test/resources/single-app-1.log"));
+        log.applyWatchStream("Ingress", "/apis/extensions/v1beta1/ingresses?labelSelector=app.kubernetes.io%2Fmanaged-by%3Dpayara-cloud&watch=true", 10, mockServer);
+        log.applyWatchStream("Deployment", "/apis/apps/v1/deployments?labelSelector=app.kubernetes.io%2Fmanaged-by%3Dpayara-cloud&watch=true", 5, mockServer);
+        log.applyWatchStream("Pod", "/api/v1/pods?labelSelector=app.kubernetes.io%2Fmanaged-by%3Dpayara-cloud&watch=true", 5, mockServer);
+        log.applyLogStream("68a78ed6-41da-11ea-95a2-920d8d1d0d91", "/api/v1/namespaces/test-dev/pods/ui-77867f97dc-7lg5n/log?pretty=false&follow=true", 5, mockServer);
+
+        var deploymentProcess = MockDeploymentProcess.get();
+
+        MockDeploymentProcess.startFixedIDProcess("6a94c593-7061-4fe6-94de-6bca574077a7", "ROOT.war", new Namespace("test","dev"), null);
+
+        try (KubernetesWatcher watcher = new KubernetesWatcher() {
+            @Override
+            protected void logEvent(Watcher.Action action, HasMetadata resource) {
+            }
+
+            @Override
+            protected void logLog(String id, ObjectMeta podMeta, byte[] chunk) {
+            }
+        }) {
+            watcher.client = mockServer.getClient();
+            watcher.executorService = Executors.newSingleThreadScheduledExecutor();
+            watcher.process = deploymentProcess;
+            watcher.startWatching();
+
+            var observer = MockDeploymentProcess.observer();
+            observer.await(ChangeKind.DEPLOYMENT_READY);
+            observer.await(ChangeKind.INGRESS_READY,11, TimeUnit.SECONDS);
+            observer.await(ChangeKind.POD_CREATED);
+            observer.await(ChangeKind.PROVISION_FINISHED);
+            observer.await(ChangeKind.OUTPUT_LOGGED);
+        }
+    }
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ConfigurationTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ConfigurationTest.java
@@ -62,15 +62,15 @@ public class ConfigurationTest {
 
     @Test
     public void addingConfigurationBroadcastsEvent() {
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf));
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(new MockConfiguration("other-mock")));
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(simple));
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf).getKind());
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(new MockConfiguration("other-mock")).getKind());
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(simple).getKind());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void addingDuplicateConfigurationFails() {
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf));
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf));
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf).getKind());
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf).getKind());
     }
 
     @Test
@@ -143,8 +143,8 @@ public class ConfigurationTest {
     @Test
     public void allConfigsCanBeSubmitted() {
         var otherMock = new MockConfiguration("other-mock");
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf));
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(otherMock));
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf).getKind());
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(otherMock).getKind());
         var update = Map.of("required", "value");
         processState.setConfiguration("mock", "id", false, update);
         processState.setConfiguration("mock", "other-mock", false, update);
@@ -160,8 +160,8 @@ public class ConfigurationTest {
     @Test
     public void configsAreSubmittedAtomically() {
         var otherMock = new MockConfiguration("other-mock");
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf));
-        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(otherMock));
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(conf).getKind());
+        assertEquals(ChangeKind.CONFIGURATION_ADDED, processState.addConfiguration(otherMock).getKind());
         var update = Map.of("required", "value");
         processState.setConfiguration("mock", "id", false, update);
         try {

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/MockDeploymentProcess.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/MockDeploymentProcess.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.process;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
+import javax.enterprise.util.TypeLiteral;
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static org.junit.Assert.assertTrue;
+
+public class MockDeploymentProcess {
+    public static final List<StateChanged> FIRED_EVENTS = Collections.synchronizedList(new ArrayList<>());
+
+    private static final ProcessObserver observer = new ProcessObserver();
+
+    private static final Event<StateChanged> mockEvent = new Event<>(){
+        @Override
+        public void fire(StateChanged event) {
+            System.out.println("Fired "+event);
+            FIRED_EVENTS.add(event);
+            observer.generalObserver(event);
+        }
+
+        @Override
+        public <U extends StateChanged> CompletionStage<U> fireAsync(U event) {
+            fire(event);
+            return CompletableFuture.completedFuture(event);
+        }
+
+        @Override
+        public <U extends StateChanged> CompletionStage<U> fireAsync(U event, NotificationOptions options) {
+            fire(event);
+            return CompletableFuture.completedFuture(event);
+        }
+
+        @Override
+        public Event<StateChanged> select(Annotation... qualifiers) {
+            return this;
+        }
+
+        @Override
+        public <U extends StateChanged> Event<U> select(Class<U> subtype, Annotation... qualifiers) {
+            return (Event<U>)this;
+        }
+
+        @Override
+        public <U extends StateChanged> Event<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            return (Event<U>)this;
+        }
+    };
+
+    private static final DeploymentProcess deploymentProcess = new DeploymentProcess() {{
+        deploymentEvent = mockEvent;
+    }};
+
+    public static DeploymentProcess get() {
+        reset();
+        return deploymentProcess;
+    }
+
+    public static ProcessObserver observer() {
+        return observer;
+    }
+
+    public static void reset() {
+        observer.reset();
+    }
+
+    public void assertFired(ChangeKind kind) {
+        assertTrue("At least one change of kind "+kind+" should have fired", FIRED_EVENTS.stream().anyMatch(e -> e.getKind() == kind));
+    }
+
+    public static DeploymentProcessState startFixedIDProcess(String id, String name, Namespace namespace, File tempLocation) {
+        return get().start(new DeploymentProcessState(id, namespace, name, tempLocation));
+    }
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessAccessor.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessAccessor.java
@@ -56,16 +56,15 @@ public class ProcessAccessor {
         if (kind == null) {
             return null;
         }
-        process.transition(kind);
-        return new StateChanged(process, kind);
+        return process.transition(kind);
     }
 
     public static StateChanged setPersistentLocation(DeploymentProcessState process, URI location) {
-        return makeEvent(process, process.setPersistentLocation(location));
+        return process.setPersistentLocation(location);
     }
 
     public static StateChanged addConfiguration(DeploymentProcessState process, Configuration configuration) {
-        return makeEvent(process, process.addConfiguration(configuration));
+        return process.addConfiguration(configuration);
     }
 
     public static DeploymentProcessState createProcessWithName(String name) {

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessObserver.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/ProcessObserver.java
@@ -104,8 +104,12 @@ public class ProcessObserver {
     }
 
     public void await(ChangeKind kind) {
+        await(kind, 5, TimeUnit.SECONDS);
+    }
+
+    public void await(ChangeKind kind, long timeOut, TimeUnit unit) {
         try {
-            assertTrue("Event "+kind+" should be fired within short time", eventLatches.get(kind).await(5, TimeUnit.SECONDS));
+            assertTrue("Event "+kind+" should be fired within "+timeOut+" "+unit, eventLatches.get(kind).await(timeOut, unit));
         } catch (InterruptedException e) {
             throw new RuntimeException("Interrupted while waiting for "+kind, e);
         }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionMonitorTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionMonitorTest.java
@@ -100,11 +100,6 @@ public class ProvisionMonitorTest {
         verifyFail(after(150).never());
     }
 
-    @Test
-    public void cleanupStartedCancelsMonitoring() {
-        controller.monitorProgress(makeEvent(process, ChangeKind.CLEANUP_STARTED));
-        verifyFail(after(150).never());
-    }
 
     private void verifyFail(VerificationMode mode) {
         verify(controller.process, mode).fail(eq(process), any(), any());

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionTimeoutIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionTimeoutIT.java
@@ -68,7 +68,7 @@ public class ProvisionTimeoutIT {
                 .addClass(ArtifactStorage.class)
                 .addClass(TempArtifactStorage.class)
                 .addClass(ManagedConcurrencyProducer.class)
-                .addAsResource(new StringAsset("provision.timeout=PT2S"), "META-INF/microprofile-config.properties");
+                .addAsResource(new StringAsset("provisioning.timeout=PT2S"), "META-INF/microprofile-config.properties");
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/resources/single-app-1.log
+++ b/deployer/deployment-controller/src/test/resources/single-app-1.log
@@ -1,0 +1,377 @@
+2020-01-28T14:28:19.840748100Z
+Event
+Deployment
+ADDED
+{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"payara.cloud/artifact":"ui","payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war","payara.cloud/domain":"9ba44192900145a88bfb.westeurope.aksapp.io","payara.cloud/project":"test","payara.cloud/stage":"dev"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772470","selfLink":"/apis/apps/v1/namespaces/test-dev/deployments/ui","uid":"689b7d39-41da-11ea-95a2-920d8d1d0d91"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"6a94c593-7061-4fe6-94de-6bca574077a7","namespace":"test-dev"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"}]}],"dnsPolicy":"ClusterFirst","initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"}]}],"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"}]}}},"status":{}}
+2020-01-28T14:28:19.849746300Z
+Event
+Deployment
+MODIFIED
+{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1","payara.cloud/artifact":"ui","payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war","payara.cloud/domain":"9ba44192900145a88bfb.westeurope.aksapp.io","payara.cloud/project":"test","payara.cloud/stage":"dev"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772472","selfLink":"/apis/apps/v1/namespaces/test-dev/deployments/ui","uid":"689b7d39-41da-11ea-95a2-920d8d1d0d91"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"6a94c593-7061-4fe6-94de-6bca574077a7","namespace":"test-dev"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"}]}],"dnsPolicy":"ClusterFirst","initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"}]}],"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"}]}}},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:10Z","lastUpdateTime":"2020-01-28T14:28:10Z","message":"Created new replica set \"ui-77867f97dc\"","reason":"NewReplicaSetCreated","status":"True","type":"Progressing"}]}}
+2020-01-28T14:28:19.871746Z
+Event
+Pod
+ADDED
+{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"creationTimestamp":"2020-01-28T14:28:10Z","generateName":"ui-77867f97dc-","labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7","pod-template-hash":"77867f97dc"},"name":"ui-77867f97dc-7lg5n","namespace":"test-dev","ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","blockOwnerDeletion":true,"controller":true,"name":"ui-77867f97dc","uid":"689f3573-41da-11ea-95a2-920d8d1d0d91"}],"resourceVersion":"4772474","selfLink":"/api/v1/namespaces/test-dev/pods/ui-77867f97dc-7lg5n","uid":"68a78ed6-41da-11ea-95a2-920d8d1d0d91"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"priority":0,"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":30,"tolerations":[{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}],"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"},{"name":"default-token-g769z","secret":{"defaultMode":420,"secretName":"default-token-g769z"}}]},"status":{"phase":"Pending","qosClass":"Burstable"}}
+2020-01-28T14:28:19.889745100Z
+Event
+Pod
+MODIFIED
+{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"creationTimestamp":"2020-01-28T14:28:10Z","generateName":"ui-77867f97dc-","labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7","pod-template-hash":"77867f97dc"},"name":"ui-77867f97dc-7lg5n","namespace":"test-dev","ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","blockOwnerDeletion":true,"controller":true,"name":"ui-77867f97dc","uid":"689f3573-41da-11ea-95a2-920d8d1d0d91"}],"resourceVersion":"4772475","selfLink":"/api/v1/namespaces/test-dev/pods/ui-77867f97dc-7lg5n","uid":"68a78ed6-41da-11ea-95a2-920d8d1d0d91"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"nodeName":"aks-nodepool1-18286783-vmss000000","priority":0,"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":30,"tolerations":[{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}],"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"},{"name":"default-token-g769z","secret":{"defaultMode":420,"secretName":"default-token-g769z"}}]},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:10Z","status":"True","type":"PodScheduled"}],"phase":"Pending","qosClass":"Burstable"}}
+2020-01-28T14:28:19.896746300Z
+Event
+Deployment
+MODIFIED
+{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1","payara.cloud/artifact":"ui","payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war","payara.cloud/domain":"9ba44192900145a88bfb.westeurope.aksapp.io","payara.cloud/project":"test","payara.cloud/stage":"dev"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772478","selfLink":"/apis/apps/v1/namespaces/test-dev/deployments/ui","uid":"689b7d39-41da-11ea-95a2-920d8d1d0d91"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"6a94c593-7061-4fe6-94de-6bca574077a7","namespace":"test-dev"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"}]}],"dnsPolicy":"ClusterFirst","initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"}]}],"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"}]}}},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:10Z","lastUpdateTime":"2020-01-28T14:28:10Z","message":"Created new replica set \"ui-77867f97dc\"","reason":"NewReplicaSetCreated","status":"True","type":"Progressing"},{"lastTransitionTime":"2020-01-28T14:28:10Z","lastUpdateTime":"2020-01-28T14:28:10Z","message":"Deployment does not have minimum availability.","reason":"MinimumReplicasUnavailable","status":"False","type":"Available"}],"observedGeneration":1,"unavailableReplicas":1}}
+2020-01-28T14:28:19.935744600Z
+Event
+Deployment
+MODIFIED
+{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1","payara.cloud/artifact":"ui","payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war","payara.cloud/domain":"9ba44192900145a88bfb.westeurope.aksapp.io","payara.cloud/project":"test","payara.cloud/stage":"dev"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772481","selfLink":"/apis/apps/v1/namespaces/test-dev/deployments/ui","uid":"689b7d39-41da-11ea-95a2-920d8d1d0d91"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"6a94c593-7061-4fe6-94de-6bca574077a7","namespace":"test-dev"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"}]}],"dnsPolicy":"ClusterFirst","initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"}]}],"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"}]}}},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:10Z","lastUpdateTime":"2020-01-28T14:28:10Z","message":"Deployment does not have minimum availability.","reason":"MinimumReplicasUnavailable","status":"False","type":"Available"},{"lastTransitionTime":"2020-01-28T14:28:10Z","lastUpdateTime":"2020-01-28T14:28:10Z","message":"ReplicaSet \"ui-77867f97dc\" is progressing.","reason":"ReplicaSetUpdated","status":"True","type":"Progressing"}],"observedGeneration":1,"replicas":1,"unavailableReplicas":1,"updatedReplicas":1}}
+2020-01-28T14:28:19.960746200Z
+Event
+Ingress
+ADDED
+{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"addon-http-application-routing"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"ingress","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772483","selfLink":"/apis/extensions/v1beta1/namespaces/test-dev/ingresses/ui","uid":"68b774a0-41da-11ea-95a2-920d8d1d0d91"},"spec":{"rules":[{"host":"test-dev.9ba44192900145a88bfb.westeurope.aksapp.io","http":{"paths":[{"backend":{"serviceName":"ui","servicePort":80},"path":"/"}]}}]},"status":{"loadBalancer":{}}}
+2020-01-28T14:28:20.023742300Z
+Event
+Pod
+MODIFIED
+{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"creationTimestamp":"2020-01-28T14:28:10Z","generateName":"ui-77867f97dc-","labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7","pod-template-hash":"77867f97dc"},"name":"ui-77867f97dc-7lg5n","namespace":"test-dev","ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","blockOwnerDeletion":true,"controller":true,"name":"ui-77867f97dc","uid":"689f3573-41da-11ea-95a2-920d8d1d0d91"}],"resourceVersion":"4772485","selfLink":"/api/v1/namespaces/test-dev/pods/ui-77867f97dc-7lg5n","uid":"68a78ed6-41da-11ea-95a2-920d8d1d0d91"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"nodeName":"aks-nodepool1-18286783-vmss000000","priority":0,"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":30,"tolerations":[{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}],"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"},{"name":"default-token-g769z","secret":{"defaultMode":420,"secretName":"default-token-g769z"}}]},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:10Z","message":"containers with incomplete status: [download-app]","reason":"ContainersNotInitialized","status":"False","type":"Initialized"},{"lastTransitionTime":"2020-01-28T14:28:10Z","message":"containers with unready status: [micro]","reason":"ContainersNotReady","status":"False","type":"Ready"},{"lastTransitionTime":"2020-01-28T14:28:10Z","message":"containers with unready status: [micro]","reason":"ContainersNotReady","status":"False","type":"ContainersReady"},{"lastTransitionTime":"2020-01-28T14:28:10Z","status":"True","type":"PodScheduled"}],"containerStatuses":[{"image":"payara/micro:jdk11","imageID":"","lastState":{},"name":"micro","ready":false,"restartCount":0,"state":{"waiting":{"reason":"PodInitializing"}}}],"hostIP":"10.240.0.4","initContainerStatuses":[{"image":"curlimages/curl:latest","imageID":"","lastState":{},"name":"download-app","ready":false,"restartCount":0,"state":{"waiting":{"reason":"PodInitializing"}}}],"phase":"Pending","qosClass":"Burstable","startTime":"2020-01-28T14:28:10Z"}}
+2020-01-28T14:28:23.779954900Z
+Event
+Pod
+MODIFIED
+{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"creationTimestamp":"2020-01-28T14:28:10Z","generateName":"ui-77867f97dc-","labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7","pod-template-hash":"77867f97dc"},"name":"ui-77867f97dc-7lg5n","namespace":"test-dev","ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","blockOwnerDeletion":true,"controller":true,"name":"ui-77867f97dc","uid":"689f3573-41da-11ea-95a2-920d8d1d0d91"}],"resourceVersion":"4772495","selfLink":"/api/v1/namespaces/test-dev/pods/ui-77867f97dc-7lg5n","uid":"68a78ed6-41da-11ea-95a2-920d8d1d0d91"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"nodeName":"aks-nodepool1-18286783-vmss000000","priority":0,"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":30,"tolerations":[{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}],"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"},{"name":"default-token-g769z","secret":{"defaultMode":420,"secretName":"default-token-g769z"}}]},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:14Z","status":"True","type":"Initialized"},{"lastTransitionTime":"2020-01-28T14:28:10Z","message":"containers with unready status: [micro]","reason":"ContainersNotReady","status":"False","type":"Ready"},{"lastTransitionTime":"2020-01-28T14:28:10Z","message":"containers with unready status: [micro]","reason":"ContainersNotReady","status":"False","type":"ContainersReady"},{"lastTransitionTime":"2020-01-28T14:28:10Z","status":"True","type":"PodScheduled"}],"containerStatuses":[{"image":"payara/micro:jdk11","imageID":"","lastState":{},"name":"micro","ready":false,"restartCount":0,"state":{"waiting":{"reason":"PodInitializing"}}}],"hostIP":"10.240.0.4","initContainerStatuses":[{"containerID":"docker://d6246ad734471fcad4d2d92edd7a828b219d346bfc9e5291eaaa0abe50ad7862","image":"curlimages/curl:latest","imageID":"docker-pullable://curlimages/curl@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151","lastState":{},"name":"download-app","ready":true,"restartCount":0,"state":{"terminated":{"containerID":"docker://d6246ad734471fcad4d2d92edd7a828b219d346bfc9e5291eaaa0abe50ad7862","exitCode":0,"finishedAt":"2020-01-28T14:28:13Z","reason":"Completed","startedAt":"2020-01-28T14:28:13Z"}}}],"phase":"Pending","podIP":"10.244.0.191","qosClass":"Burstable","startTime":"2020-01-28T14:28:10Z"}}
+2020-01-28T14:28:24.843075400Z
+Event
+Pod
+MODIFIED
+{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"creationTimestamp":"2020-01-28T14:28:10Z","generateName":"ui-77867f97dc-","labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7","pod-template-hash":"77867f97dc"},"name":"ui-77867f97dc-7lg5n","namespace":"test-dev","ownerReferences":[{"apiVersion":"apps/v1","kind":"ReplicaSet","blockOwnerDeletion":true,"controller":true,"name":"ui-77867f97dc","uid":"689f3573-41da-11ea-95a2-920d8d1d0d91"}],"resourceVersion":"4772501","selfLink":"/api/v1/namespaces/test-dev/pods/ui-77867f97dc-7lg5n","uid":"68a78ed6-41da-11ea-95a2-920d8d1d0d91"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"default-token-g769z","readOnly":true}]}],"nodeName":"aks-nodepool1-18286783-vmss000000","priority":0,"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":30,"tolerations":[{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}],"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"},{"name":"default-token-g769z","secret":{"defaultMode":420,"secretName":"default-token-g769z"}}]},"status":{"conditions":[{"lastTransitionTime":"2020-01-28T14:28:14Z","status":"True","type":"Initialized"},{"lastTransitionTime":"2020-01-28T14:28:15Z","status":"True","type":"Ready"},{"lastTransitionTime":"2020-01-28T14:28:15Z","status":"True","type":"ContainersReady"},{"lastTransitionTime":"2020-01-28T14:28:10Z","status":"True","type":"PodScheduled"}],"containerStatuses":[{"containerID":"docker://86d523560ba8e5bcff407e73eda58ffdfd2bc41ba54ceeec952578a0a8ad55d3","image":"payara/micro:jdk11","imageID":"docker-pullable://payara/micro@sha256:eef7d1eacf09429485a04192389ba6ac493905bcfa34309fa03d68e6884704f2","lastState":{},"name":"micro","ready":true,"restartCount":0,"state":{"running":{"startedAt":"2020-01-28T14:28:14Z"}}}],"hostIP":"10.240.0.4","initContainerStatuses":[{"containerID":"docker://d6246ad734471fcad4d2d92edd7a828b219d346bfc9e5291eaaa0abe50ad7862","image":"curlimages/curl:latest","imageID":"docker-pullable://curlimages/curl@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151","lastState":{},"name":"download-app","ready":true,"restartCount":0,"state":{"terminated":{"containerID":"docker://d6246ad734471fcad4d2d92edd7a828b219d346bfc9e5291eaaa0abe50ad7862","exitCode":0,"finishedAt":"2020-01-28T14:28:13Z","reason":"Completed","startedAt":"2020-01-28T14:28:13Z"}}}],"phase":"Running","podIP":"10.244.0.191","qosClass":"Burstable","startTime":"2020-01-28T14:28:10Z"}}
+2020-01-28T14:28:24.902074300Z
+Event
+Deployment
+MODIFIED
+{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1","payara.cloud/artifact":"ui","payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war","payara.cloud/domain":"9ba44192900145a88bfb.westeurope.aksapp.io","payara.cloud/project":"test","payara.cloud/stage":"dev"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772505","selfLink":"/apis/apps/v1/namespaces/test-dev/deployments/ui","uid":"689b7d39-41da-11ea-95a2-920d8d1d0d91"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"annotations":{"payara.cloud/artifact-url":"https://cloud3.blob.core.windows.net/deployment/micro1/ROOT.war"},"labels":{"app.kubernetes.io/component":"payara-app","app.kubernetes.io/instance":"ui","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"6a94c593-7061-4fe6-94de-6bca574077a7","namespace":"test-dev"},"spec":{"containers":[{"args":["--deploymentDir","/opt/payara/deployments","--clustermode","dns:6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900"],"image":"payara/micro:jdk11","imagePullPolicy":"IfNotPresent","name":"micro","ports":[{"containerPort":8080,"name":"http","protocol":"TCP"},{"containerPort":6900,"name":"datagrid","protocol":"TCP"}],"resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"250m"}},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/opt/payara/deployments","name":"deployments"}]}],"dnsPolicy":"ClusterFirst","initContainers":[{"args":["-c","cd /deployments && curl -O `cat /podinfo/url`"],"command":["sh"],"image":"curlimages/curl:latest","imagePullPolicy":"Always","name":"download-app","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/deployments","name":"deployments"},{"mountPath":"/podinfo","name":"podinfo"}]}],"restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30,"volumes":[{"emptyDir":{},"name":"deployments"},{"downwardAPI":{"defaultMode":420,"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.annotations['payara.cloud/artifact-url']"},"path":"url"}]},"name":"podinfo"}]}}},"status":{"availableReplicas":1,"conditions":[{"lastTransitionTime":"2020-01-28T14:28:15Z","lastUpdateTime":"2020-01-28T14:28:15Z","message":"Deployment has minimum availability.","reason":"MinimumReplicasAvailable","status":"True","type":"Available"},{"lastTransitionTime":"2020-01-28T14:28:10Z","lastUpdateTime":"2020-01-28T14:28:15Z","message":"ReplicaSet \"ui-77867f97dc\" has successfully progressed.","reason":"NewReplicaSetAvailable","status":"True","type":"Progressing"}],"observedGeneration":1,"readyReplicas":1,"replicas":1,"updatedReplicas":1}}
+2020-01-28T14:28:26.082791800Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+763
+[2020-01-28T14:28:16.305+0000] [] [[1;93mWARNING[0m] [] [[1;94mPayaraMicro[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221696305] [levelValue: 900] Payara Micro Runtime directory is located in a temporary file location which can be cleaned by system processes.
+
+[2020-01-28T14:28:16.427+0000] [] [[1;92mINFO[0m] [] [[1;94mPayaraMicro[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221696427] [levelValue: 800] Payara Micro Runtime directory is located at /tmp/payaramicro-rt501868735241456950tmp
+
+[2020-01-28T14:28:16.493+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.micro.boot.runtime.PayaraMicroRuntimeBuilder[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221696493] [levelValue: 800] Built Payara Micro Runtime
+
+
+2020-01-28T14:28:28.084943100Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+283
+[2020-01-28T14:28:18.458+0000] [] [[1;92mINFO[0m] [NCLS-CORE-00046] [[1;94mjavax.enterprise.system.core[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221698458] [levelValue: 800] Cannot find javadb client jar file, derby jdbc driver will not be available by default.
+
+
+2020-01-28T14:28:30.088426100Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+[2020-01-28T14:28:19.734+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.boot.runtime.BootCommand[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221699734] [levelValue: 800] [[
+  Boot Command set returned with result SUCCESS : PlainTextActionReporterSUCCESSDescription: set AdminCommandnull
+    configs.config.server-config.hazelcast-config-specific-configuration.lite=false
+]]
+
+[2020-01-28T14:28:19.803+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.boot.runtime.BootCommand[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221699803] [levelValue: 800] [[
+  Boot Command set returned with result SUCCESS : PlainTextActionReporterSUCCESSDescription: set AdminCommandnull
+    hazelcast-runtime-configuration.host-aware-partitioning=true
+]]
+
+[2020-01-28T14:28:19.815+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.boot.runtime.BootCommand[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221699815] [levelValue: 800] [[
+  Boot Command set returned with result SUCCESS : PlainTextActionRepo
+2020-01-28T14:28:31.090991200Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+892
+rterSUCCESSDescription: set AdminCommandnull
+    hazelcast-runtime-configuration.dns-members=6a94c593-7061-4fe6-94de-6bca574077a7-datagrid:6900
+]]
+
+[2020-01-28T14:28:19.829+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.boot.runtime.BootCommand[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221699829] [levelValue: 800] [[
+  Boot Command set returned with result SUCCESS : PlainTextActionReporterSUCCESSDescription: set AdminCommandnull
+    hazelcast-runtime-configuration.discovery-mode=dns
+]]
+
+[2020-01-28T14:28:21.407+0000] [] [[1;92mINFO[0m] [] [[1;94morg.glassfish.ha.store.spi.BackingStoreFactoryRegistry[0m] [tid: _ThreadID=20 _ThreadName=RunLevelControllerThread-1580221699906] [timeMillis: 1580221701407] [levelValue: 800] Registered fish.payara.ha.hazelcast.store.HazelcastBackingStoreFactoryProxy for persistence-type = hazelcast in BackingStoreFactoryRegistry
+
+
+2020-01-28T14:28:32.094527900Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+900
+[2020-01-28T14:28:22.309+0000] [] [[1;92mINFO[0m] [NCLS-CORE-00101] [[1;94mjavax.enterprise.system.core[0m] [tid: _ThreadID=21 _ThreadName=RunLevelControllerThread-1580221699909] [timeMillis: 1580221702309] [levelValue: 800] Network Listener http-listener started in: 87ms - bound to [/0.0.0.0:8080]
+
+[2020-01-28T14:28:22.336+0000] [] [[1;92mINFO[0m] [NCLS-CORE-00058] [[1;94mjavax.enterprise.system.core[0m] [tid: _ThreadID=21 _ThreadName=RunLevelControllerThread-1580221699909] [timeMillis: 1580221702336] [levelValue: 800] Network listener https-listener on port 8443 disabled per domain.xml
+
+[2020-01-28T14:28:22.339+0000] [] [[1;92mINFO[0m] [NCLS-CORE-00087] [[1;94mjavax.enterprise.system.core[0m] [tid: _ThreadID=21 _ThreadName=RunLevelControllerThread-1580221699909] [timeMillis: 1580221702339] [levelValue: 800] Grizzly 2.4.3 started in: 1,856ms - bound to [http-listener:8080]
+
+
+2020-01-28T14:28:35.098271800Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+[2020-01-28T14:28:25.097+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221705097] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:25.108+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221705108] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:25.132+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221705132] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:25.173+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.n
+2020-01-28T14:28:36.101005200Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+ucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221705173] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:25.254+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221705254] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:25.415+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221705415] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:25.736+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=23 _ThreadName=RunLev
+2020-01-28T14:28:37.102201700Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+elControllerThread-1580221699924] [timeMillis: 1580221705736] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:26.306+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221706306] [levelValue: 800] Hazelcast Instance Bound to JNDI at payara/Hazelcast
+
+[2020-01-28T14:28:26.309+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221706309] [levelValue: 800] JSR107 Caching Provider Bound to JNDI at payara/CachingProvider
+
+[2020-01-28T14:28:26.310+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=23 _ThreadName=RunLevelControllerThread-1580221699924] [timeMillis: 1580221706310] [levelValue: 800] JSR107 Default Cache Manager Bound to JNDI at payara/CacheMan
+2020-01-28T14:28:38.103269200Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+ager
+
+[2020-01-28T14:28:26.625+0000] [] [[1;92mINFO[0m] [NCLS-CORE-00017] [[1;94mjavax.enterprise.system.core[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221706625] [levelValue: 800] Payara Micro  5.194 #badassmicrofish (327) startup time : Embedded (3,403ms), startup services(6,724ms), total(10,127ms)
+
+[2020-01-28T14:28:26.994+0000] [] [[1;92mINFO[0m] [NCLS-JMX-00006] [[1;94mjavax.enterprise.system.jmx[0m] [tid: _ThreadID=72 _ThreadName=Thread-6] [timeMillis: 1580221706994] [levelValue: 800] JMXStartupService has disabled JMXConnector system
+
+[2020-01-28T14:28:27.987+0000] [] [[1;93mWARNING[0m] [NCLS-SECURITY-05054] [[1;94mjavax.enterprise.system.security.ssl[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221707987] [levelValue: 900] [[
+  The SSL certificate has expired: [
+[
+  Version: V3
+  Subject: CN=Entrust.net Certification Authority (2048), OU=(c) 1999 Entrust.net Limited, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), O=Entrust.net
+  Signature Algorithm: 
+2020-01-28T14:28:39.105033800Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+SHA1withRSA, OID = 1.2.840.113549.1.1.5
+
+  Key:  Sun RSA public key, 2048 bits
+  params: null
+  modulus: 21877342614735064986586094209008949861633415438321046094865735894101046869669024974234189221129376235137504163448391667494521959302368300673495711648664420351966300087244240539893392975177816108541817252818998001932142985065266407504518566289301698937041931668276581800733716890145024940625536991682725365140451115767110550542345758164504698636529042078537609343076050570785483670809094993963575569689277704991843533760219663288836022206035538841969109577376809337618824179167781883694301066738001489513517818892302945620562766589172426570508291886401623875028645352783701438149952282706361006848685772598444243814369
+  public exponent: 65537
+  Validity: [From: Fri Dec 24 17:50:51 GMT 1999,
+               To: Tue Dec 24 18:20:51 GMT 2019]
+  Issuer: CN=Entrust.net Certification Authority (2048), OU=(c) 1999 Entrust.net Limited, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), O=Entrust.net
+  SerialNumber
+2020-01-28T14:28:40.106688700Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+: [    3863b966]
+
+Certificate Extensions: 4
+[1]: ObjectId: 1.2.840.113533.7.65.0 Criticality=false
+Extension unknown: DER encoded OCTET string =
+0000: 04 10 30 0E 1B 08 56 35   2E 30 3A 34 2E 30 03 02  ..0...V5.0:4.0..
+0010: 04 90                                              ..
+
+
+[2]: ObjectId: 2.5.29.35 Criticality=false
+AuthorityKeyIdentifier [
+KeyIdentifier [
+0000: 55 E4 81 D1 11 80 BE D8   89 B9 08 A3 31 F9 A1 24  U...........1..$
+0010: 09 16 B9 70                                        ...p
+]
+]
+
+[3]: ObjectId: 2.16.840.1.113730.1.1 Criticality=false
+NetscapeCertType [
+   SSL CA
+   S/MIME CA
+   Object Signing CA]
+
+[4]: ObjectId: 2.5.29.14 Criticality=false
+SubjectKeyIdentifier [
+KeyIdentifier [
+0000: 55 E4 81 D1 11 80 BE D8   89 B9 08 A3 31 F9 A1 24  U...........1..$
+0010: 09 16 B9 70                                        ...p
+]
+]
+
+]
+  Algorithm: [SHA1withRSA]
+  Signature:
+0000: 59 47 AC 21 84 8A 17 C9   9C 89 53 1E BA 80 85 1A  YG.!......S.....
+0010: C6 3C 4E 3E B1 9C B6 7C   C6 92 5D 18 64 02 E3 D3  .<
+2020-01-28T14:28:41.108856200Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+N>......].d...
+0020: 06 08 11 61 7C 63 E3 2B   9D 31 03 70 76 D2 A3 28  ...a.c.+.1.pv..(
+0030: A0 F4 BB 9A 63 73 ED 6D   E5 2A DB ED 14 A9 2B C6  ....cs.m.*....+.
+0040: 36 11 D0 2B EB 07 8B A5   DA 9E 5C 19 9D 56 12 F5  6..+......\..V..
+0050: 54 29 C8 05 ED B2 12 2A   8D F4 03 1B FF E7 92 10  T).....*........
+0060: 87 B0 3A B5 C3 9D 05 37   12 A3 C7 F4 15 B9 D5 A4  ..:....7........
+0070: 39 16 9B 53 3A 23 91 F1   A8 82 A2 6A 88 68 C1 79  9..S:#.....j.h.y
+0080: 02 22 BC AA A6 D6 AE DF   B0 14 5F B8 87 D0 DD 7C  ."........_.....
+0090: 7F 7B FF AF 1C CF E6 DB   07 AD 5E DB 85 9D D0 2B  ..........^....+
+00A0: 0D 33 DB 04 D1 E6 49 40   13 2B 76 FB 3E E9 9C 89  .3....I@.+v.>...
+00B0: 0F 15 CE 18 B0 85 78 21   4F 6B 4F 0E FA 36 67 CD  ......x!OkO..6g.
+00C0: 07 F2 FF 08 D0 E2 DE D9   BF 2A AF B8 87 86 21 3C  .........*....!<
+00D0: 04 CA B7 94 68 7F CF 3C   E9 98 D7 38 FF EC C0 D9  ....h..<...8....
+00E0: 50 F0 2E 4B 58 AE 46 6F   D0 2E C3 60 DA 72 55 72  P..KX.Fo...`.rUr
+00F0: BD 4C 45 9E 61 BA BF 84   81 92 03 D1 D2 
+2020-01-28T14:28:42.109848500Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+69 7C C5  .LE.a........i..
+
+]]]
+
+[2020-01-28T14:28:28.032+0000] [] [[1;92mINFO[0m] [NCLS-SECURITY-01002] [[1;94mjavax.enterprise.system.core.security[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221708032] [levelValue: 800] Java security manager is disabled.
+
+[2020-01-28T14:28:28.081+0000] [] [[1;92mINFO[0m] [NCLS-SECURITY-01010] [[1;94mjavax.enterprise.system.core.security[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221708081] [levelValue: 800] Entering Security Startup Service.
+
+[2020-01-28T14:28:28.091+0000] [] [[1;92mINFO[0m] [NCLS-SECURITY-01143] [[1;94mjavax.enterprise.system.core.security[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221708091] [levelValue: 800] Loading policy provider com.sun.enterprise.security.jacc.provider.SimplePolicyProvider.
+
+[2020-01-28T14:28:28.136+0000] [] [[1;92mINFO[0m] [NCLS-SECURITY-01011] [[1;94mjavax.enterprise.system.core.security[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221708136] [levelValue: 800] Se
+2020-01-28T14:28:43.111720100Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+curity Service(s) started successfully.
+
+[2020-01-28T14:28:28.908+0000] [] [[1;92mINFO[0m] [AS-WEB-GLUE-00198] [[1;94mjavax.enterprise.web[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221708908] [levelValue: 800] Created HTTP listener http-listener on host/port 0.0.0.0:8080
+
+[2020-01-28T14:28:28.985+0000] [] [[1;92mINFO[0m] [AS-WEB-GLUE-00200] [[1;94mjavax.enterprise.web[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221708985] [levelValue: 800] Created virtual server server
+
+[2020-01-28T14:28:29.709+0000] [] [[1;92mINFO[0m] [AS-WEB-GLUE-00201] [[1;94mjavax.enterprise.web[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221709709] [levelValue: 800] Virtual server server loaded default web module 
+
+[2020-01-28T14:28:33.407+0000] [] [[1;92mINFO[0m] [] [[1;94mjavax.enterprise.system.core[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713407] [levelValue: 800] ROOT was successfully deployed in 5,908 milliseconds.
+
+[2020-01-28T14:28:33.411+0000] [] [[1;92
+2020-01-28T14:28:44.112584400Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+mINFO[0m] [] [[1;94mPayaraMicro[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713411] [levelValue: 800] Deployed 1 archive(s)
+
+[2020-01-28T14:28:33.488+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713488] [levelValue: 800] Hazelcast Instance Unbound from JNDI at payara/Hazelcast
+
+[2020-01-28T14:28:33.489+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713489] [levelValue: 800] JSR107 Caching Provider Unbound from JNDI at payara/CachingProvider
+
+[2020-01-28T14:28:33.489+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713489] [levelValue: 800] JSR107 Cache Manager Unbound from JNDI at payara/CacheManager
+
+[2020-01-28T14:28:33.538+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[
+2020-01-28T14:28:45.113470Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713538] [levelValue: 800] Shutdown Hazelcast
+
+[2020-01-28T14:28:33.597+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713597] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:33.608+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713608] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:33.628+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713628] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:33.669+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.
+2020-01-28T14:28:46.114681900Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713669] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:33.750+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713750] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:33.914+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221713914] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca574077a7-datagrid
+
+[2020-01-28T14:28:34.235+0000] [] [[1;93mWARNING[0m] [] [[1;94mfish.payara.nucleus.hazelcast.DnsDiscoveryService[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221714235] [levelValue: 900] Unable to find DNS record for 6a94c593-7061-4fe6-94de-6bca5
+2020-01-28T14:28:47.116744700Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+74077a7-datagrid
+
+[2020-01-28T14:28:34.738+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221714738] [levelValue: 800] Hazelcast Instance Bound to JNDI at payara/Hazelcast
+
+[2020-01-28T14:28:34.739+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221714739] [levelValue: 800] JSR107 Caching Provider Bound to JNDI at payara/CachingProvider
+
+[2020-01-28T14:28:34.740+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.hazelcast.HazelcastCore[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221714740] [levelValue: 800] JSR107 Default Cache Manager Bound to JNDI at payara/CacheManager
+
+[2020-01-28T14:28:34.743+0000] [] [[1;92mINFO[0m] [] [[1;94mfish.payara.nucleus.cluster.PayaraCluster[0m] [tid: _ThreadID=97 _ThreadName=Executor-Service-11] [timeMillis: 1580221714743] [levelValue: 800] [[
+  Data Grid Status 
+Payara 
+2020-01-28T14:28:48.117054Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1024
+Data Grid State: DG Version: 35 DG Name: development DG Size: 1
+Instances: {
+ DataGrid: development Instance Group: MicroShoal Name: Bamboozled-Pufferfish Lite: false This: true UUID: 14b131eb-cb0c-4b8b-a704-1201e720db3d Address: /10.244.0.191:6900
+}]]
+
+[2020-01-28T14:28:34.782+0000] [] [[1;92mINFO[0m] [AS-WEB-GLUE-00130] [[1;94mjavax.enterprise.web[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221714782] [levelValue: 800] Invalid Session Management Configuration for non-distributable app [ROOT] - defaulting to memory: persistence-type = [hazelcast] / persistenceFrequency = [web-method] / persistenceScope = [modified-session]
+
+[2020-01-28T14:28:34.995+0000] [] [[1;92mINFO[0m] [AS-WEB-GLUE-00172] [[1;94mjavax.enterprise.web[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221714995] [levelValue: 800] Loading application [ROOT] at [/]
+
+[2020-01-28T14:28:35.203+0000] [] [[1;92mINFO[0m] [] [[1;94mPayaraMicro[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221715203] [levelV
+2020-01-28T14:28:49.119086500Z
+Log
+68a78ed6-41da-11ea-95a2-920d8d1d0d91
+1010
+alue: 800] [[
+  
+{
+    "Instance Configuration": {
+        "Host": "ui-77867f97dc-7lg5n",
+        "Http Port(s)": "8080",
+        "Https Port(s)": "",
+        "Instance Name": "Bamboozled-Pufferfish",
+        "Instance Group": "MicroShoal",
+        "Hazelcast Member UUID": "14b131eb-cb0c-4b8b-a704-1201e720db3d",
+        "Deployed": [
+            {
+                "Name": "ROOT",
+                "Type": "war",
+                "Context Root": "/"
+            }
+        ]
+    }
+}]]
+
+[2020-01-28T14:28:35.214+0000] [] [[1;92mINFO[0m] [] [[1;94mPayaraMicro[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221715214] [levelValue: 800] [[
+  
+Payara Micro URLs:
+http://ui-77867f97dc-7lg5n:8080/
+
+'ROOT' REST Endpoints:
+GET	/openapi/
+GET	/openapi/application.wadl
+
+]]
+
+[2020-01-28T14:28:35.214+0000] [] [[1;92mINFO[0m] [] [[1;94mPayaraMicro[0m] [tid: _ThreadID=1 _ThreadName=main] [timeMillis: 1580221715214] [levelValue: 800] Payara Micro  5.194 #badassmicrofish (build 327) ready in 19,002 (ms)
+
+
+2020-01-28T14:29:16.997991700Z
+Event
+Ingress
+MODIFIED
+{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"addon-http-application-routing"},"creationTimestamp":"2020-01-28T14:28:10Z","generation":1,"labels":{"app.kubernetes.io/component":"ingress","app.kubernetes.io/managed-by":"payara-cloud","app.kubernetes.io/name":"ui","app.kubernetes.io/part-of":"6a94c593-7061-4fe6-94de-6bca574077a7"},"name":"ui","namespace":"test-dev","resourceVersion":"4772578","selfLink":"/apis/extensions/v1beta1/namespaces/test-dev/ingresses/ui","uid":"68b774a0-41da-11ea-95a2-920d8d1d0d91"},"spec":{"rules":[{"host":"test-dev.9ba44192900145a88bfb.westeurope.aksapp.io","http":{"paths":[{"backend":{"serviceName":"ui","servicePort":80},"path":"/"}]}}]},"status":{"loadBalancer":{"ingress":[{"ip":"51.124.89.195"}]}}}


### PR DESCRIPTION
* KubernetesWatcher updates deployment process state.
* Refined ChangeKinds with more types of changes
* PROVISION_FINISHED is now automatically fired after ingress and deployment are ready
* Rudimentary support for capturing pod logs during provisioning

Testing:
* CreateTestManual captures events relevant for watcher and stores them into format understood by StoredLog
* StoredLog parses the files and configured mock kubernetes server to play the events back
* Mock deployment process to test the interaction of a component and deployment process in larger unit test

Ouput Log events are specialization of state changed and contain individual chunk. For that entire responsibility of creating event was moved into `DeploymentProcessState`, and the responsibility for correctly annotating the event back to `DeploymentProcess`.

Testing against live cluster demonstrated a bug in watches, where client sometime produce incorrect requests and they need to be adapted.

Provision now finishes after deployment is ready and ingress is ready, purely based on consumed Kubernetes events.

Frontend now displays log output of instance that is starting up.