### PR TITLE
Cloud-35: Configuration UI

### DIFF
--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/configuration/ConfigurationController.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/configuration/ConfigurationController.java
@@ -58,7 +58,7 @@ class ConfigurationController {
     void startConfiguration(@ObservesAsync @ChangeKind.Filter(ChangeKind.INSPECTION_FINISHED) StateChanged event) {
         deploymentProcess.configurationStarted(event.getProcess());
         
-        if (autoSubmit && event.getProcess().isConfigurationComplete()) {
+        if ((autoSubmit || event.getProcess().isUsingDefaultConfiguration()) && event.getProcess().isConfigurationComplete()) {
             deploymentProcess.submitConfigurations(event.getProcess());
         }
         // Some tasks that this might do as well:

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/Application.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/Application.java
@@ -61,6 +61,7 @@ public class Application extends javax.ws.rs.core.Application {
         classes.add(DeploymentResource.class);
         classes.add(MultiPartFeature.class);
         classes.add(Version.class);
+        classes.add(UnpolyRedirectFilter.class);
         return classes;
     }
     

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/DeploymentResource.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/DeploymentResource.java
@@ -190,7 +190,7 @@ public class DeploymentResource {
     
     @GET
     @Path("{id}")
-    public Response displayDeployment(@PathParam("id") String id, @Context UriInfo uriInfo) {
+    public Response redirectToDeploymentDir(@PathParam("id") String id, @Context UriInfo uriInfo) {
         // redirect to {id}/
         return Response.seeOther(uriInfo.resolve(URI.create(id+"/"))).build();
     }    

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/MvcModels.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/MvcModels.java
@@ -47,6 +47,7 @@ import fish.payara.cloud.deployer.process.DeploymentProcessState;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.Optional;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Model;
 import javax.enterprise.inject.Produces;
@@ -73,7 +74,13 @@ class MvcModels {
 
     @Produces @Model
     public ConfigBean getConfig() {
-        return deployment == null ? null : ConfigBean.forDeploymentProcess(deployment);
+        if (config != null) {
+            return config;
+        }
+        if (deployment != null) {
+            return ConfigBean.forDeploymentProcess(deployment);
+        }
+        return null;
     }
 
     @Produces @Model
@@ -99,5 +106,9 @@ class MvcModels {
     @Produces @Model
     public String lastStateTimestamp() {
         return deployment == null || deployment.getLastStatusChange() == null ? null : SHORT_TIME.format(deployment.getLastStatusChange());
+    }
+
+    void setConfig(ConfigBean configBean) {
+        config = configBean;
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootConfiguration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootConfiguration.java
@@ -69,6 +69,24 @@ public class ContextRootConfiguration extends Configuration {
     }
 
     @Override
+    public boolean isRequired(String key) {
+        return true;
+    }
+
+    @Override
+    protected void checkUpdate(UpdateContext context) {
+        super.checkUpdate(context);
+        context.key(CONTEXT_ROOT).check(v -> {
+            if (!v.startsWith("/")) throw new IllegalArgumentException("Value must start with a slash");
+        });
+        context.key(APP_NAME).check(v -> {
+            if (v.isBlank()) throw new IllegalArgumentException("Name must be provided");
+        });
+    }
+    
+    
+
+    @Override
     public Optional<String> getDefaultValue(String key) {
         switch (key) {
             case CONTEXT_ROOT:

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
@@ -69,6 +69,9 @@ public abstract class Configuration {
      * @param id id of the configuration
      */
     protected Configuration(String id) {
+        if (id.contains(":")) {
+            throw new IllegalArgumentException("Invalid configuration id "+id+" name cannot contain colon");
+        }
         this.id = id;
     }
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcess.java
@@ -43,7 +43,6 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import java.io.File;
 import java.net.URI;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,7 +56,7 @@ import java.util.function.Function;
  */
 @ApplicationScoped
 public class DeploymentProcess {
-    private ConcurrentHashMap<String, DeploymentProcessState> runningProcesses = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, DeploymentProcessState> runningProcesses = new ConcurrentHashMap<>();
 
     @Inject
     Event<StateChanged> deploymentEvent;
@@ -73,6 +72,11 @@ public class DeploymentProcess {
         var processState = new DeploymentProcessState(target, name, artifactLocation);
         return start(processState);
     }
+    
+    public DeploymentProcessState startWithDefaultConfiguration(File artifactLocation, String name, Namespace target) {
+        var processState = new DeploymentProcessState(target, name, artifactLocation, true);
+        return start(processState);
+    }    
 
     DeploymentProcessState start(DeploymentProcessState processState) {
         runningProcesses.put(processState.getId(), processState);

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
@@ -87,19 +87,22 @@ public class DeploymentProcessState {
     private Instant endpointActivatedAt;
     private Instant deploymentCompletedAt;
     private DeploymentProcessLogOutput logOutput;
-   
+    private final boolean usingDefaultConfiguration;
+    
     DeploymentProcessState(Namespace target, String name, File tempLocation) {
-        this.id = UUID.randomUUID().toString();
-        this.namespace = target;
-        this.name = name;
-        this.tempLocation = tempLocation;
+        this(UUID.randomUUID().toString(), target, name, tempLocation, false);
     }
+    
+    DeploymentProcessState(Namespace target, String name, File tempLocation, boolean usingDefaultConfiguration) {
+        this(UUID.randomUUID().toString(), target, name, tempLocation, usingDefaultConfiguration);
+    }    
 
-    DeploymentProcessState(String id, Namespace target, String name, File tempLocation) {
+    DeploymentProcessState(String id, Namespace target, String name, File tempLocation, boolean usingDefaultConfiguration) {
         this.id = id;
         this.namespace = target;
         this.name = name;
         this.tempLocation = tempLocation;
+        this.usingDefaultConfiguration = usingDefaultConfiguration;
     }
 
     /**
@@ -363,4 +366,8 @@ public class DeploymentProcessState {
     public boolean isReady() {
         return endpointActivatedAt != null && deploymentCompletedAt != null;
     }
+
+    public boolean isUsingDefaultConfiguration() {
+        return usingDefaultConfiguration;
+    }   
 }

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
@@ -61,7 +61,7 @@
                 </div>
                     </c:when>
                     <c:when test="#{deployment.configurable}">
-                <p class="pending secondary-white">Configuration pending</p>
+                        <section class="pending secondary-white"><h3>Configuration pending</h3>
                         <c:choose>
                             <c:when test="${deployment.configurationComplete}">
                                 <form action="configuration/submit" method="post" up-target="#status"><button>Confirm configured values</button></form>
@@ -70,12 +70,15 @@
                                 <p>Some of configuration objects below need your attention</p>
                             </c:otherwise>
                         </c:choose>
+                    </section>
 
 
                         <c:forEach items="${config.order}" var="configKey">
+                            <section>
                             <comp:view-single-config config-id="${configKey.id}" kind="${configKey.kind}"
                                                      config="${config.kind[configKey.kind][configKey.id]}"
                                                      />
+                            </section>
                         </c:forEach>
                     </c:when>
                     <c:otherwise>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
@@ -35,64 +35,86 @@
   ~  and therefore, elected the GPL Version 2 license, then the option applies
   ~  only if the new code is made subject to such option by the copyright
   ~  holder.
-  -->
+-->
 <ui:composition template="layout.xhtml" xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:comp="http://xmlns.jcp.org/jsf/composite/cloud-deploy">
     <ui:define name="main">
         <h2>Deployment #{deployment.name}</h2>
         <main>
-        <h4>Stage: #{deployment.namespace.project}-#{deployment.namespace.stage}</h4>
+            <h4>Stage: #{deployment.namespace.project}-#{deployment.namespace.stage}</h4>
         <div id="status">
-        <c:choose>
-            <c:when test="#{deployment.failed}">
-                <h3>Failed</h3>
-                <p>#{deployment.completionMessage}</p>
-            </c:when>
-            <c:when test="#{deployment.ready}">
+                <c:choose>
+                    <c:when test="#{deployment.failed}">
+                        <h3>Failed</h3>
+                        <p>#{deployment.completionMessage}</p>
+                    </c:when>
+                    <c:when test="#{deployment.ready}">
                 <div class="success secondary-white">
-                <h3>Success!</h3>
-                <p>#{deployment.completionMessage}</p>
+                        <h3>Success!</h3>
+                        <p>#{deployment.completionMessage}</p>
                 <div class="result secondary-white">
-                    <a href="#{deployment.endpoint}" target="_blank">#{deployment.endpoint}</a>
+                            <a href="#{deployment.endpoint}" target="_blank">#{deployment.endpoint}</a>
+                        </div>
                 </div>
-                </div>
-            </c:when>
-            <c:when test="#{deployment.configurable}">
+                    </c:when>
+                    <c:when test="#{deployment.configurable}">
                 <p class="pending secondary-white">Configuration pending</p>
-            </c:when>
-            <c:otherwise>
-                <progress/>
+                        <c:choose>
+                            <c:when test="${deployment.configurationComplete}">
+                                <form action="configuration/submit" method="post" up-target="#status"><button>Confirm configured values</button></form>
+                            </c:when> 
+                            <c:otherwise>
+                                <p>Some of configuration objects below need your attention</p>
+                            </c:otherwise>
+                        </c:choose>
+
+
+                        <c:forEach items="${config.order}" var="configKey">
+                            <comp:view-single-config config-id="${configKey.id}" kind="${configKey.kind}"
+                                                     config="${config.kind[configKey.kind][configKey.id]}"
+                                                     />
+                        </c:forEach>
+                    </c:when>
+                    <c:otherwise>
+                        <progress/>
                 <p class="pending secondary-white">Deploying...</p>
-                <p>#{deployment.lastStatusChange} #{deployment.lastChange}</p>
-            </c:otherwise>
-        </c:choose>
+                        <p>#{lastStateTimestamp} #{deployment.lastChange}</p>
+                    </c:otherwise>
+                </c:choose>
 
-        </div>
+            </div>
 
-        <textarea id="log" readonly="readonly" rows="25" style="visibility: hidden">
+            <textarea id="log" readonly="readonly" rows="25" style="visibility: hidden">
 
-        </textarea>
+            </textarea>
 
-        <form id="refreshform" up-target="#status" up-cache="false" up-history="false" method="get">
-            <button id="refresh" type="submit">Refresh</button>
-        </form>
+            <form id="refreshform" up-target="#status" up-cache="false" up-history="false" method="get">
+                <button id="refresh" type="submit">Refresh</button>
+            </form>
         </main>
 
-      <script type="text/javascript">
-        //<![CDATA[
+        <script type="text/javascript">
+            //<![CDATA[
             try {
                 const eventStream = new EventSource(window.location);
                 eventStream.onmessage = (event) => {
                     if (event.data) {
-                        // untyped event represent deployment event, let's refresh
+                        // untyped event represent deployment event
+                        const payload = JSON.parse(event.data);
                         console.log(event);
+                        if (payload.kind === "CONFIGURATION_SET") {
+                            // with configuration set this handler clashes with
+                            // form submission, therefore we skip this
+                            return;
+                        }
                         document.getElementById("refresh").click();
                     }
                 }
                 eventStream.addEventListener("state", (event) => {
-                    console.log("state event",event);
+                    console.log("state event", event);
                     const payload = JSON.parse(event.data);
                     if (payload.complete) {
                         eventStream.close();
@@ -102,13 +124,13 @@
                     console.log("log event", event);
                     const el = document.getElementById('log');
                     el.style.visibility = "visible";
-                    el.value = el.value+event.data;
+                    el.value = el.value + event.data;
                     el.scrollTop = el.scrollHeight;
                 });
-            } catch(e) {
+            } catch (e) {
                 console.log("Could not connect to SSE stream");
             }
-        //]]>
-     </script>
+            //]]>
+        </script>
     </ui:define>
 </ui:composition>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment.xhtml
@@ -64,22 +64,22 @@
                         <section class="pending secondary-white"><h3>Configuration pending</h3>
                         <c:choose>
                             <c:when test="${deployment.configurationComplete}">
-                                <form action="configuration/submit" method="post" up-target="#status"><button>Confirm configured values</button></form>
+                                <button onclick="document.getElementById('config').submit()">Confirm configured values</button>
                             </c:when> 
                             <c:otherwise>
                                 <p>Some of configuration objects below need your attention</p>
                             </c:otherwise>
                         </c:choose>
-                    </section>
+                        </section>
 
-
+                        <form id="config" action="${mvc.uri('ConfigurationResource#configAll', { 'deploymentId':deployment.id })}" method="post" up-target="#status" enctype="multipart/form-data">
                         <c:forEach items="${config.order}" var="configKey">
-                            <section>
-                            <comp:view-single-config config-id="${configKey.id}" kind="${configKey.kind}"
+                            <comp:edit-single-config config-id="${configKey.id}" kind="${configKey.kind}"
                                                      config="${config.kind[configKey.kind][configKey.id]}"
                                                      />
-                            </section>
                         </c:forEach>
+                            <button class="highlight">Confirm configured values</button>
+                        </form>
                     </c:when>
                     <c:otherwise>
                         <progress/>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/edit-configuration.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/edit-configuration.xhtml
@@ -46,11 +46,13 @@
         <main>
             <c:set var="elementId" value="config-${configKind}-${configId.replace('.','-')}"/>
             <div id="${elementId}">
-                <form method="post" up-target="#${elementId}" enctype="application/x-www-form-urlencoded">
+                <form method="post" up-target="#${elementId}" enctype="application/x-www-form-urlencoded" class="block">
                 <c:set var="currentConfig" value="${config.kind[configKind][configId]}"/>
                 <c:forEach items="${currentConfig.keydetails}" var="key">
+                    <div class="field">
                     <label for="${key.name}">${key.name}</label>
                     <input id="${key.name}" name="${key.name}" value="${currentConfig.values[key.name]}"/>
+                    </div>
                 </c:forEach>
                 <input type="submit" value="Save"/>
             </form>

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/edit-configuration.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/edit-configuration.xhtml
@@ -35,38 +35,26 @@
   ~  and therefore, elected the GPL Version 2 license, then the option applies
   ~  only if the new code is made subject to such option by the copyright
   ~  holder.
-  -->
-
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
-<head>
-    <title>Payara Cloud Deploy</title>
-    <meta http-equiv="content-type" content="text/html;charset=utf-8"/>
-    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,700&amp;display=swap" rel="stylesheet"/>
-    <link href="${request.contextPath}/main.css" rel="stylesheet"/>
-    <link href="${request.contextPath}/webjars/unpoly/0.61.0/dist/unpoly.min.css"/>
-    <script type="text/javascript" defer="defer" src="${request.contextPath}/webjars/unpoly/0.61.0/dist/unpoly.js" onload="initUnpoly()"></script>
-    <script type="text/javascript">//<![CDATA[
-    function initUnpoly() {
-        up.on('up:proxy:load', function(event) {
-            // request html (otherwise chosen by random by server
-            event.request.headers['Accept'] = 'text/html,*/*;q=0.8';
-        });
-    }
-    //]]></script>
-</head>
-<body>
-    <f:view transient="true">
-    <header>
-    <h1><a href="${request.contextPath}/"><img src="${request.contextPath}/images/logo.svg" alt="Payara " class="logo"/>Cloud Deploy</a></h1>
-    </header>
-    <ui:insert name="main"/>
-    <footer>
-        &#169; 2020 Payara Services Ltd.
-    </footer>
-    </f:view>
-</body>
-</html>
+-->
+<ui:composition template="layout.xhtml" xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:comp="http://xmlns.jcp.org/jsf/composite/cloud-deploy">
+    <ui:define name="main">
+        <h2>Configuration ${configKind}/${configId}</h2>
+        <main>
+            <c:set var="elementId" value="config-${configKind}-${configId.replace('.','-')}"/>
+            <div id="${elementId}">
+                <form method="post" up-target="#${elementId}" enctype="application/x-www-form-urlencoded">
+                <c:set var="currentConfig" value="${config.kind[configKind][configId]}"/>
+                <c:forEach items="${currentConfig.keydetails}" var="key">
+                    <label for="${key.name}">${key.name}</label>
+                    <input id="${key.name}" name="${key.name}" value="${currentConfig.values[key.name]}"/>
+                </c:forEach>
+                <input type="submit" value="Save"/>
+            </form>
+            </div>
+        </main>
+    </ui:define>
+</ui:composition>

--- a/deployer/deployment-controller/src/main/webapp/index.html
+++ b/deployer/deployment-controller/src/main/webapp/index.html
@@ -59,6 +59,9 @@
                 <input id="stage" name="stage" required type="text" pattern="[a-zA-Z0-9]{1,30}" placeholder="DNS-like name, at least one character">
                 <p><label for="artifact">Artifact <sup>(required)</sup></label><a class="hint">?</a></p>
                 <input type="file" accept=".war" id="artifact" name="artifact" class="button" required/>
+                <fieldset>
+                    <input type="checkbox" id="defaultConfig" name="defaultConfig" value="true"> <label for="defaultConfig">Use default configuration</label>
+                </fieldset>
                 <input type="submit" value="Deploy" class="button highlight">
             </form>
         </main>

--- a/deployer/deployment-controller/src/main/webapp/index.html
+++ b/deployer/deployment-controller/src/main/webapp/index.html
@@ -52,17 +52,23 @@
             What shall we deploy?
         </h2>
         <main>
-            <form enctype="multipart/form-data" action="api/deployment" method="post">
-                <p><label for="project">Project <sup>(required)</sup></label><a class="hint">?</a></p>
-                <input id="project" name="project" required type="text" pattern="[a-zA-Z0-9-]{4,30}" placeholder="DNS-like name, at least 4 characters (required)">
-                <p><label for="stage">Stage <sup>(required)</sup></label><a class="hint">?</a></p>
-                <input id="stage" name="stage" required type="text" pattern="[a-zA-Z0-9]{1,30}" placeholder="DNS-like name, at least one character">
-                <p><label for="artifact">Artifact <sup>(required)</sup></label><a class="hint">?</a></p>
-                <input type="file" accept=".war" id="artifact" name="artifact" class="button" required/>
-                <fieldset>
-                    <input type="checkbox" id="defaultConfig" name="defaultConfig" value="true"> <label for="defaultConfig">Use default configuration</label>
-                </fieldset>
-                <input type="submit" value="Deploy" class="button highlight">
+            <form enctype="multipart/form-data" action="api/deployment" method="post" class="block">
+                <div class="field">
+                    <label for="project">Project <sup>(required)</sup></label><a class="hint">?</a>
+                    <input id="project" name="project" required type="text" pattern="[a-zA-Z0-9-]{4,30}" placeholder="DNS-like name, at least 4 characters (required)">
+                </div>
+                <div class="field">
+                    <label for="stage">Stage <sup>(required)</sup></label><a class="hint">?</a>
+                    <input id="stage" name="stage" required type="text" pattern="[a-zA-Z0-9]{1,30}" placeholder="DNS-like name, at least one character">
+                </div>
+                <div class="field">
+                <label for="artifact">Artifact <sup>(required)</sup></label><a class="hint">?</a>
+                <input type="file" accept=".war" id="artifact" name="artifact" required/>
+                </div>
+                <div class="field">
+                <input type="checkbox" id="defaultConfig" name="defaultConfig" value="true"> <label for="defaultConfig">Use default configuration</label>
+                </div>
+                <input type="submit" value="Deploy" class="highlight">
             </form>
         </main>
         <footer>

--- a/deployer/deployment-controller/src/main/webapp/main.css
+++ b/deployer/deployment-controller/src/main/webapp/main.css
@@ -135,7 +135,7 @@ section {
     border-radius: 6px;
 }
 
-main > form, form.block {
+main > form, form.block, .form {
     background-color: rgba(218,224,226,0.5);
     color: #434445;
     display: grid;

--- a/deployer/deployment-controller/src/main/webapp/main.css
+++ b/deployer/deployment-controller/src/main/webapp/main.css
@@ -75,16 +75,14 @@ footer {
     bottom: 0;
 }
 
-header h1, h2, div.result {
+header h1, h2, div.result, main {
     margin: auto;
     width: 40rem;
-    padding: 1rem;
+    padding: 28px 0;
 }
 
-main {
-    margin: auto;
-    width: 40rem;
-    margin-top: 2rem;
+header + h2 {
+    margin-top: 28px;
 }
 
 h1,h2,h3,.primary-orange,h1 a {
@@ -92,9 +90,12 @@ h1,h2,h3,.primary-orange,h1 a {
 }
 
 h2, div.result {
-    margin-top: 24px;
     text-align: center;
     color: #002c3e;
+}
+
+div.result {
+    margin-top: 24px;
 }
 
 h1 a {
@@ -107,27 +108,39 @@ h1 a {
 
 img.logo {
     width: 10em;
+    margin-right: 1em;
+    vertical-align: bottom;
+    position: relative;
+    top: 0.15em;
 }
 
 .secondary-light {
     color: #dae0e2;
 }
 
-
 .secondary-dark {
     color: #434445;
 }
 
-.secondary-white {
+.secondary-white, .secondary-white h3 {
     color: #FFFFFF;
 }
 
-form {
-    background-color: #dae0e2;
+.block {
+    padding: 40px 48px 56px 48px; 
+    margin-bottom: 56px;
+}
+
+section {
+    border-radius: 6px;
+}
+
+main > form, form.block {
+    background-color: rgba(218,224,226,0.5);
     color: #434445;
-    margin-top: 56px;
-    padding: 0px 48px 56px 48px;
     display: grid;
+    grid-row-gap: 32px;
+    border-radius: 6px;
 }
 
 label {
@@ -153,9 +166,16 @@ sup {
     padding: 4px;
     margin: 12px;
     cursor: pointer;
-    transition-delay: 0.3s;
+    transition-duration: 0.3s;
     transition-property: transform;
     transition-timing-function: ease-out;
+    width: 1.2em;
+    display: inline-block;
+}
+
+form.single-action {
+    text-align: center;
+    padding: 12px;
 }
 
 .hint:hover {
@@ -168,7 +188,7 @@ progress {
     margin: auto;
 }
 
-.button {
+.button, button, input[type=submit] {
     color: #101012;
     background-color: #dae0e2;
     border-radius: 3px;
@@ -177,22 +197,40 @@ progress {
     font-weight: 500;
     cursor: pointer;
     padding: 12px 24px;
-    transition-delay: 0.1s;
+    transition-duration: 0.1s;
     transition-property: transform;
-    box-shadow: 0 -1px 0 0 rgba(134,151,156,128) inset;
-        
+    border: 0px none;
+}
+    
+.button.highlight, button.highlight, input[type=submit].highlight {
+    background: rgb(240,152,27);
+    box-shadow: 0 -1px 0 0 rgba(128,74,0,0.5) inset;
 }
 
-.button.highlight {
+.button.highlight:hover, button.highlight:hover, input[type=submit].highlight:hover {
+    background-color: rgba(240,152,27,0.9);
+}
+
+.field input:not([type=checkbox]) {
+    display: block;
+    width: 100%;
+}
+
+.button.default, button.default, input[type=submit].default{
     background-color: #F0981B;
-    box-shadow: 0 -1px 0 0 rgba(128,74,0,128) inset;
+    box-shadow: 0 -1px 0 0 rgba(134,151,156,0.5) inset;
 }
 
-.button:hover {
+.button:hover, button:hover, input[type=submit]:hover {
     transform: translate(0px, 2px);
+    background-color: rgba(195,203,206,0.8);
 }
+
 
 .pending {
+    min-height: 5em;
+    text-align: center;
+    padding: 2em 0.5em;
     background-color: #4E5A5E;
 }
 
@@ -237,6 +275,7 @@ input[type=checkbox], input[type=radio] {
     border-width: 1px;
     height: 24px;
     width: 24px;
+    vertical-align: baseline;
 }
 
 checkbox:hover, radio:hover {

--- a/deployer/deployment-controller/src/main/webapp/resources/cloud-deploy/edit-single-config.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/resources/cloud-deploy/edit-single-config.xhtml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:composite="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:c="http://java.sun.com/jsp/jstl/core">
+<composite:interface>
+    <composite:attribute name="kind" required="true" type="java.lang.String"/>
+    <composite:attribute name="config-id" required="true" type="java.lang.String"/>
+    <composite:attribute name="config" required="true" type="fish.payara.cloud.deployer.process.ConfigBean$Config"/>
+</composite:interface>
+
+<composite:implementation>
+    <section class="block form">
+    <h3>Configuration <em>${cc.attrs.kind}</em> of <em>${cc.attrs['config-id']}</em></h3>
+        <c:set var="values" value="${cc.attrs.config.values}"/>
+        <c:forEach items="${cc.attrs.config.keydetails}" var="key">
+            <div class="field">
+                <label for="${key.updateKey}">${key.name}<c:if test="${key.required}"> <sup>(required)</sup></c:if></label>
+            <input id="${key.updateKey}" name="${key.updateKey}" value="${values[key.name]}" required="${key.required ? 'required' : ''}"
+                   invalid="${key.errorMessage != null ? 'invalid':''}"/>
+            <c:if test="${key.errorMessage != null}">
+                <div class="error">${key.errorMessage}</div>
+            </c:if>
+            </div>
+        </c:forEach>
+    </section>
+</composite:implementation>
+</html>

--- a/deployer/deployment-controller/src/main/webapp/resources/cloud-deploy/view-single-config.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/resources/cloud-deploy/view-single-config.xhtml
@@ -36,37 +36,34 @@
   ~  only if the new code is made subject to such option by the copyright
   ~  holder.
   -->
-
-<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:composite="http://xmlns.jcp.org/jsf/composite"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
-<head>
-    <title>Payara Cloud Deploy</title>
-    <meta http-equiv="content-type" content="text/html;charset=utf-8"/>
-    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,700&amp;display=swap" rel="stylesheet"/>
-    <link href="${request.contextPath}/main.css" rel="stylesheet"/>
-    <link href="${request.contextPath}/webjars/unpoly/0.61.0/dist/unpoly.min.css"/>
-    <script type="text/javascript" defer="defer" src="${request.contextPath}/webjars/unpoly/0.61.0/dist/unpoly.js" onload="initUnpoly()"></script>
-    <script type="text/javascript">//<![CDATA[
-    function initUnpoly() {
-        up.on('up:proxy:load', function(event) {
-            // request html (otherwise chosen by random by server
-            event.request.headers['Accept'] = 'text/html,*/*;q=0.8';
-        });
-    }
-    //]]></script>
-</head>
-<body>
-    <f:view transient="true">
-    <header>
-    <h1><a href="${request.contextPath}/"><img src="${request.contextPath}/images/logo.svg" alt="Payara " class="logo"/>Cloud Deploy</a></h1>
-    </header>
-    <ui:insert name="main"/>
-    <footer>
-        &#169; 2020 Payara Services Ltd.
-    </footer>
-    </f:view>
-</body>
+      xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:c="http://java.sun.com/jsp/jstl/core">
+<composite:interface>
+    <composite:attribute name="kind" required="true" type="java.lang.String"/>
+    <composite:attribute name="config-id" required="true" type="java.lang.String"/>
+    <composite:attribute name="config" required="true" type="fish.payara.cloud.deployer.process.ConfigBean$Config"/>
+</composite:interface>
+
+<composite:implementation>
+    <h3>Configuration <em>${cc.attrs.kind}</em> of <em>${cc.attrs['config-id']}</em></h3>
+    <c:set var="elementId" value="config-${cc.attrs.kind}-${cc.attrs['config-id'].replace('.','-')}"/>
+    <div id="${elementId}">
+    <table>
+        <c:set var="values" value="${cc.attrs.config.values}"/>
+        <c:forEach items="${cc.attrs.config.keydetails}" var="key">
+            <tr>
+                <th>${key.name}</th>
+                <td><input readonly="readonly" value="${values[key.name]}" disabled="disabled"/></td>
+            </tr>
+        </c:forEach>
+    </table>
+
+    <form method="get" up-target="#${elementId}" action="configuration/${cc.attrs.kind}/${cc.attrs['config-id']}">
+        <button>Edit</button>
+    </form>
+    </div>
+</composite:implementation>
 </html>

--- a/deployer/deployment-controller/src/main/webapp/resources/cloud-deploy/view-single-config.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/resources/cloud-deploy/view-single-config.xhtml
@@ -61,7 +61,7 @@
         </c:forEach>
     </table>
 
-    <form method="get" up-target="#${elementId}" action="configuration/${cc.attrs.kind}/${cc.attrs['config-id']}">
+    <form method="get" up-target="#${elementId}" action="configuration/${cc.attrs.kind}/${cc.attrs['config-id']}" class="single-action">
         <button>Edit</button>
     </form>
     </div>

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/configuration/ConfigurationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/configuration/ConfigurationIT.java
@@ -96,4 +96,14 @@ public class ConfigurationIT {
         deployment.submitConfigurations(process);
         observer.await(ChangeKind.CONFIGURATION_FINISHED);
     }
+    
+    @Test
+    public void configurationIsAutomaticallySubmittedWhenUsingDefaults() {
+        var testFile = write(ShrinkWrap.create(WebArchive.class)
+                .addAsManifestResource(new StringAsset("artifactId=maven-artifact"), "maven/fish.payara.cloud.test/test/pom.properties"));
+        observer.reset();
+        var process = deployment.startWithDefaultConfiguration(testFile, "test-app.war", new Namespace("test","dev"));
+        observer.await(ChangeKind.CONFIGURATION_STARTED);
+        observer.await(ChangeKind.CONFIGURATION_FINISHED);
+    }    
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/ConfigurationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/ConfigurationIT.java
@@ -123,7 +123,7 @@ public class ConfigurationIT {
 
         var client = ClientBuilder.newClient().target(uri).path("api/deployment/").path(state.getId());
 
-        var submittedConfigState = client.path("configuration/").queryParam("submit", "true").request().post(null, ConfigBean.class);
+        var submittedConfigState = client.path("configuration/").queryParam("submit", "true").request(APPLICATION_JSON_TYPE).post(null, ConfigBean.class);
 
         assertNotNull(submittedConfigState.getKind().get(KIND));
         var contextRootConfig = submittedConfigState.getKind().get(KIND).get("test.war");
@@ -150,7 +150,7 @@ public class ConfigurationIT {
         assertEquals("other-test", contextRootConfig.getValues().get(APP_NAME));
         assertEquals("/other", contextRootConfig.getValues().get(CONTEXT_ROOT));
 
-        var resetConfigState = client.queryParam("submit", "false").request()
+        var resetConfigState = client.queryParam("submit", "false").request(APPLICATION_JSON_TYPE)
                 .post(null, ConfigBean.class);
 
         contextRootConfig = resetConfigState.getKind().get(KIND).get("test.war");

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/WatchIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/WatchIT.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
  * Capture is created from {@link CreateTestManual#inspectWatches()}, which stores Kubernetes events in a format
  * understood by {@link StoredLog} and these are then fed into mock kubernetes server
  */
-public class WatchTest {
+public class WatchIT {
     @Rule
     public KubernetesServer mockServer = new KubernetesServer();
 

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/MockDeploymentProcess.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/MockDeploymentProcess.java
@@ -114,6 +114,6 @@ public class MockDeploymentProcess {
     }
 
     public static DeploymentProcessState startFixedIDProcess(String id, String name, Namespace namespace, File tempLocation) {
-        return get().start(new DeploymentProcessState(id, namespace, name, tempLocation));
+        return get().start(new DeploymentProcessState(id, namespace, name, tempLocation, false));
     }
 }


### PR DESCRIPTION
With "Use default configuration" the deployment behaves as when autosubmit was turned on -- all configuration was automatically submitted if there were no missing values.

A filter was added to support unpoly's [Redirection protocol](https://unpoly.com/form-up-target) - AJAX client cannot tell if it was redirected, so without that additional header, browser's location remained at form action.

Layout now includes transient JSF view root, which is probably necessary for using composite components. Or at least for dropping state encoding phase.

Adapted to new UI:
![TW6KriY4rB](https://user-images.githubusercontent.com/1588543/74242633-94231800-4cde-11ea-9f43-b8831e79c9b2.gif)

![UMgL2Evot0](https://user-images.githubusercontent.com/1588543/74242662-9b4a2600-4cde-11ea-883b-3cbb8b3ae727.gif)

