### PR TITLE
Cloud-26 CLOUD-36: Support for microprofile config

### DIFF
--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/InspectedArtifact.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/InspectedArtifact.java
@@ -138,8 +138,16 @@ public class InspectedArtifact {
         }
 
         @Override
-        public boolean matches(String regExp) {
+        public boolean pathMatches(String regExp) {
             return getName().matches(regExp);
+        }
+
+        private static final String WAR_CLASS_ROOT="WEB-INF/classes/";
+
+        @Override
+        public boolean classpathMatches(String regExp) {
+            // for now we hardcode .war file path
+            return getName().startsWith(WAR_CLASS_ROOT) && getName().substring(WAR_CLASS_ROOT.length()).matches(regExp);
         }
     }
 }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/Inspection.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/Inspection.java
@@ -67,7 +67,8 @@ public interface Inspection {
         boolean isDirectory();
         Optional<ArtifactEntry> getParent();
 
-        boolean matches(String regExp);
+        boolean pathMatches(String regExp);
+        boolean classpathMatches(String regExp);
 
         InputStream getInputStream() throws IOException;
     }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootInspection.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootInspection.java
@@ -41,17 +41,12 @@ package fish.payara.cloud.deployer.inspection.contextroot;
 import fish.payara.cloud.deployer.inspection.InspectedArtifact;
 import fish.payara.cloud.deployer.inspection.Inspection;
 import fish.payara.cloud.deployer.inspection.InspectionException;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.enterprise.context.Dependent;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathEvaluationResult;
 import javax.xml.xpath.XPathException;
-import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathNodes;
 import java.io.IOException;
@@ -72,9 +67,9 @@ class ContextRootInspection implements Inspection {
 
     @Override
     public void inspect(ArtifactEntry entry, InspectedArtifact artifact) throws IOException {
-        if (entry.matches("META-INF/maven/[^/]+/[^/]+/pom.properties")) {
+        if (entry.pathMatches("META-INF/maven/[^/]+/[^/]+/pom.properties")) {
             inspectPomProperties(entry);
-        } else if (entry.matches("WEB-INF/glassfish-web.xml")) {
+        } else if (entry.pathMatches("WEB-INF/glassfish-web.xml")) {
             inspectGlassfishDescriptor(entry);
         }
     }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/mpconfig/MicroprofileConfigInspection.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/mpconfig/MicroprofileConfigInspection.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.inspection.mpconfig;
+
+import fish.payara.cloud.deployer.inspection.InspectedArtifact;
+import fish.payara.cloud.deployer.inspection.Inspection;
+
+import javax.el.CompositeELResolver;
+import javax.enterprise.context.Dependent;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+@Dependent
+class MicroprofileConfigInspection implements Inspection {
+    private List<MicroprofileConfiguration> configs = new ArrayList<>();
+
+    @Override
+    public void inspect(ArtifactEntry entry, InspectedArtifact artifact) throws IOException {
+        if (entry.classpathMatches("META-INF/microprofile-config.properties")) {
+            addConfig(artifact.getName(), entry.getInputStream());
+        }
+    }
+
+    private void addConfig(String name, InputStream inputStream) throws IOException {
+        Properties config = new Properties();
+        config.load(inputStream);
+        this.configs.add(new MicroprofileConfiguration(name, config));
+    }
+
+    @Override
+    public void finish(InspectedArtifact artifact) {
+        configs.forEach(artifact::addConfiguration);
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/mpconfig/MicroprofileConfiguration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/mpconfig/MicroprofileConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.inspection.mpconfig;
+
+import fish.payara.cloud.deployer.process.Configuration;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+public class MicroprofileConfiguration extends Configuration {
+
+    public static final String KIND = "microprofileConfig";
+    private final Properties inspectedValues;
+
+    public MicroprofileConfiguration(String name, Properties inspectedValues) {
+        super(name);
+        this.inspectedValues = inspectedValues;
+    }
+
+    @Override
+    public String getKind() {
+        return KIND;
+    }
+
+    @Override
+    public Set<String> getKeys() {
+        return additionalKeysAnd(inspectedValues.stringPropertyNames());
+    }
+
+    @Override
+    public Optional<String> getDefaultValue(String key) {
+        if (inspectedValues.containsKey(key)) {
+            return Optional.of(inspectedValues.getProperty(key));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean supportsAdditionalKeys() {
+        return true;
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
@@ -40,12 +40,16 @@ package fish.payara.cloud.deployer.process;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Base class for deployment configuration.
@@ -63,6 +67,7 @@ public abstract class Configuration {
     private final String id;
     private boolean submitted;
     private final Map<String,String> updatedValues = new HashMap<>();
+    private final Set<String> additionalKeys = new HashSet<>();
 
     /**
      * Create configuration with given id.
@@ -113,6 +118,29 @@ public abstract class Configuration {
      * @return unmodifiable collection of keys
      */
     public abstract Set<String> getKeys();
+
+    /**
+     * Concatenate set of base keys with additonal keys
+     * This is helper method for configurations {@linkplain #supportsAdditionalKeys() supporting additonal keys} to
+     * include additional keys in return value of {@link #getKeys()}
+     * @param baseKeys base keys of the configuration
+     * @return concatenation of baseKeys and additonal keys
+     */
+    protected Set<String> additionalKeysAnd(Set<String> baseKeys) {
+        if (additionalKeys.isEmpty()) {
+            return baseKeys;
+        } else {
+            return Stream.concat(baseKeys.stream(), additionalKeys.stream()).collect(Collectors.toSet());
+        }
+    }
+
+    /**
+     * Indicate whether additional keys can be specified in update operation
+     * @return true if keys different to those reported by {@link #getKeys()} can be updated
+     */
+    public boolean supportsAdditionalKeys() {
+        return false;
+    }
 
     /**
      * Determine if a key is required in this configuration.
@@ -171,12 +199,18 @@ public abstract class Configuration {
      * During check operation, {@link #getValue(String)} method will return previous value for the key. To obtain
      * updated value, use {@link UpdateContext#getValue(String)}.
      * Runtime exceptions thrown from this method are added as validation errors in context active at time of throw.
+     * Default implementation reports error when unknown keys are present and {@link #supportsAdditionalKeys()} is false
      * @param context the context of the update
      * @see UpdateContext#convertAndCheck(Function, Consumer)
      * @see UpdateContext#key(String)
      * @see UpdateContext#addValidationError(String)
      */
     protected void checkUpdate(UpdateContext context) {
+        if (!supportsAdditionalKeys() && !context.additonalKeys().isEmpty()) {
+            context.additonalKeys().forEach(key -> {
+               context.key(key).addValidationError("Unsupported configuration key");
+            });
+        }
     }
 
 
@@ -191,7 +225,8 @@ public abstract class Configuration {
             ctx.addValidationError(t.getMessage());
         }
         if (ctx.isValid()) {
-            updatedValues.putAll(values);
+            updatedValues.putAll(ctx.updateValues);
+            additionalKeys.addAll(ctx.additionalKeys);
         } else {
             throw new ConfigurationValidationException(getKind(), getId(), ctx.mainValidationError, ctx.validationErrors);
         }
@@ -242,12 +277,15 @@ public abstract class Configuration {
     protected class UpdateContext {
         private final Map<String, String> updateValues;
         private final Map<String, String> validationErrors = new HashMap<>();
+        private final HashSet<String> additionalKeys;
         private String mainValidationError;
         private String validationContext;
 
 
         private UpdateContext(Map<String,String> values) {
-            this.updateValues = Collections.unmodifiableMap(Objects.requireNonNull(values, "values are required for update"));
+            this.updateValues = new HashMap<>(Objects.requireNonNull(values, "values are required for update"));
+            this.additionalKeys = new HashSet<>(values.keySet());
+            additionalKeys.removeAll(getKeys());
         }
 
         /**
@@ -278,6 +316,13 @@ public abstract class Configuration {
         }
 
         /**
+         * List of keys not listed in {@link Configuration#getKeys()}
+         */
+        public Set<String> additonalKeys() {
+            return additionalKeys;
+        }
+
+        /**
          * Check if value is updated in this operation
          * @param key key to check
          * @return true if value is updated in this operation
@@ -297,6 +342,18 @@ public abstract class Configuration {
             } else {
                 return Configuration.this.getValue(key);
             }
+        }
+
+        /**
+         * Remove a key from updated keys.
+         * Configuration can accept additional keys, but may ignore some of them and decide not to store them.
+         * In such case a key can be removed
+         * @param key key to remove
+         * @return true if key was present in updated keys
+         */
+        public boolean remove(String key) {
+            additionalKeys.remove(key);
+            return updateValues.remove(key) != null;
         }
 
         /**

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
@@ -225,11 +225,18 @@ public abstract class Configuration {
             ctx.addValidationError(t.getMessage());
         }
         if (ctx.isValid()) {
-            updatedValues.putAll(ctx.updateValues);
             additionalKeys.addAll(ctx.additionalKeys);
+            updatedValues.putAll(ctx.updateValues);
+            ctx.removedKeys.forEach(updatedValues::remove);
+            ctx.removedAdditionalKeys.forEach(additionalKeys::remove);
+            removeDefaultValues();
         } else {
             throw new ConfigurationValidationException(getKind(), getId(), ctx.mainValidationError, ctx.validationErrors);
         }
+    }
+
+    private void removeDefaultValues() {
+        updatedValues.entrySet().removeIf(entry -> Objects.equals(entry.getValue(), getDefaultValue(entry.getKey()).orElse(null)));
     }
 
     /**
@@ -267,6 +274,10 @@ public abstract class Configuration {
         updatedValues.clear();
     }
 
+    public boolean hasOverrides() {
+        return !updatedValues.isEmpty();
+    }
+
     /**
      * The context of the update. Method {@link #checkUpdate(UpdateContext)} utilize this class to validate fields
      * and report validation errors.
@@ -277,15 +288,28 @@ public abstract class Configuration {
     protected class UpdateContext {
         private final Map<String, String> updateValues;
         private final Map<String, String> validationErrors = new HashMap<>();
-        private final HashSet<String> additionalKeys;
+        private final HashSet<String> additionalKeys = new HashSet<>();
+        private final HashSet<String> removedAdditionalKeys = new HashSet<>();
+        private final HashSet<String> removedKeys = new HashSet<>();
         private String mainValidationError;
         private String validationContext;
 
 
         private UpdateContext(Map<String,String> values) {
             this.updateValues = new HashMap<>(Objects.requireNonNull(values, "values are required for update"));
-            this.additionalKeys = new HashSet<>(values.keySet());
-            additionalKeys.removeAll(getKeys());
+            this.updateValues.entrySet().forEach(entry -> {
+                var key = entry.getKey();
+                boolean isAdditionalKey = Configuration.this.additionalKeys.contains(key) || !getKeys().contains(key);
+                if (isAdditionalKey) {
+                    additionalKeys.add(key);
+                }
+                if (entry.getValue() == null) {
+                    removedKeys.add(key);
+                    if (isAdditionalKey) {
+                        removedAdditionalKeys.add(key);
+                    }
+                }
+            });
         }
 
         /**

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
@@ -271,8 +271,24 @@ public class DeploymentProcessState {
         }
     }
 
-    private Optional<Configuration> findConfiguration(String kind, String id) {
+    public Optional<Configuration> findConfiguration(String kind, String id) {
         return configurations.stream().filter(c -> c.getKind().equals(kind) && c.getId().equals(id)).findAny();
+    }
+
+    public Optional<Configuration> findConfiguration(String kind) {
+        return findConfiguration(kind, getName());
+    }
+
+    public boolean hasConfiguration(String kind, String id) {
+        return findConfiguration(kind, id).isPresent();
+    }
+
+    public boolean hasConfiguration(String kind) {
+        return hasConfiguration(kind, getName());
+    }
+
+    public boolean hasConfigurationOverrides(String kind) {
+        return findConfiguration(kind).map(Configuration::hasOverrides).orElse(false);
     }
     
     StateChanged transition(ChangeKind target) {

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/inspection/mpconfig/MicroprofileConfigInspectionTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/inspection/mpconfig/MicroprofileConfigInspectionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.inspection.mpconfig;
+
+import fish.payara.cloud.deployer.inspection.InspectedArtifact;
+import fish.payara.cloud.deployer.process.ProcessAccessor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.zip.ZipFile;
+
+import static fish.payara.cloud.deployer.inspection.InspectionHelper.write;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MicroprofileConfigInspectionTest {
+    @Test
+    public void noConfigFoundWhenNoPropertyFile() throws IOException {
+        var testFile = write(ShrinkWrap.create(WebArchive.class)
+                .add(new StringAsset("<html></html>"), "index.html"));
+        assertNull(discoveredConfig("empty", testFile));
+    }
+
+    @Test
+    public void configFoundWhenPropertyPresent() throws IOException {
+        var testFile = write(ShrinkWrap.create(WebArchive.class)
+                .add(new StringAsset("<html></html>"), "index.html")
+                .addAsResource(new StringAsset("prop.1=one\nprop/second=2\nempty="), "META-INF/microprofile-config.properties"));
+        var config = discoveredConfig("configured", testFile);
+        assertNotNull(config);
+        assertTrue("All keys from file should be discovered", config.getKeys().containsAll(Set.of("prop.1", "prop/second")));
+        assertEquals("one", config.getValue("prop.1").get());
+        assertEquals("2", config.getValue("prop/second").get());
+        assertEquals("", config.getValue("empty").get());
+        // let's try updates as well
+
+        ProcessAccessor.updateConfiguration(config, Map.of("prop.1","ONE", "other", "O"));
+
+        assertEquals("ONE", config.getValue("prop.1").get());
+        assertEquals("one", config.getDefaultValue("prop.1").get());
+        assertEquals("O", config.getValue("other").get());
+        assertFalse(config.getDefaultValue("other").isPresent());
+    }
+
+    private MicroprofileConfiguration discoveredConfig(String name, File testFile) throws IOException {
+        var inspection = new MicroprofileConfigInspection();
+        var artifact = InspectedArtifact.inspect(name, new ZipFile(testFile), List.of(inspection));
+        var config = artifact.getConfigurations().stream().filter(c -> c.getKind().equals(MicroprofileConfiguration.KIND))
+                .map(MicroprofileConfiguration.class::cast).findAny().orElse(null);
+        return config;
+    }
+}


### PR DESCRIPTION
When `microprofile-config.properties` is present on the classpath, its keys are offered for configuration.

On API level, new keys can be added to configurations that support it, UI has no means for that yet.

Config is then provisioned as ConfigMap, where a single key contains entire properties file, that gets used as system properties for Micro.