### PR TITLE
CLOUD-45: Scan persistence.xml for datasource references

### DIFF
--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootInspection.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/contextroot/ContextRootInspection.java
@@ -41,13 +41,13 @@ package fish.payara.cloud.deployer.inspection.contextroot;
 import fish.payara.cloud.deployer.inspection.InspectedArtifact;
 import fish.payara.cloud.deployer.inspection.Inspection;
 import fish.payara.cloud.deployer.inspection.InspectionException;
+import fish.payara.cloud.deployer.utils.Xml;
+import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import javax.enterprise.context.Dependent;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathException;
-import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathNodes;
 import java.io.IOException;
 import java.util.Properties;
@@ -77,17 +77,12 @@ class ContextRootInspection implements Inspection {
     private void inspectGlassfishDescriptor(ArtifactEntry entry) throws IOException {
 
         try {
-            var dbf = DocumentBuilderFactory.newInstance();
-            dbf.setValidating(false);
-            dbf.setExpandEntityReferences(false);
-            dbf.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            var document = dbf.newDocumentBuilder().parse(entry.getInputStream());
-            var factory = XPathFactory.newInstance();
-            var result = factory.newXPath().evaluateExpression("/glassfish-web-app/context-root/text()", document, XPathNodes.class);
+            Document document = Xml.parse(entry.getInputStream());
+            XPathNodes result = Xml.xpath(document, "/glassfish-web-app/context-root/text()");
             if (result.size() == 1) {
                 descriptorRoot = result.get(0).getTextContent();
             }
-        } catch (ParserConfigurationException | SAXException | XPathException e) {
+        } catch (SAXException | XPathException e) {
             throw new InspectionException("Failed to parse glassfish-web.xml", e);
         }
     }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/datasource/DatasourceConfiguration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/datasource/DatasourceConfiguration.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.inspection.datasource;
+
+import fish.payara.cloud.deployer.process.Configuration;
+
+import java.util.EnumMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DatasourceConfiguration extends Configuration {
+    static final String DEFAULT_URL = "<default>";
+    static final String DEFAULT_NAME = "java:comp/DefaultDataSource";
+    public static final String KIND = "dataSource";
+
+    private final EnumMap<Key, String> defaultValues = new EnumMap<>(Key.class);
+
+    DatasourceConfiguration(String jndiName) {
+        super(jndiName);
+        defaultValues.put(Key.steadypoolsize, "1");
+        defaultValues.put(Key.maxpoolsize, "10");
+        defaultValues.put(Key.maxwaittime, "30000");
+    }
+
+    static DatasourceConfiguration createDefault() {
+        var result = new DatasourceConfiguration(DEFAULT_NAME);
+        result.defaultValues.put(Key.jdbcurl, DEFAULT_URL);
+        return result;
+    }
+
+    @Override
+    public String getKind() {
+        return KIND;
+    }
+
+    @Override
+    public Set<String> getKeys() {
+        return Stream.of(Key.values()).map(Key::name).collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isRequired(String key) {
+        return find(key).filter(Key::isRequired).isPresent();
+    }
+
+    @Override
+    public Optional<String> getDefaultValue(String key) {
+        return find(key).map(defaultValues::get);
+    }
+
+    @Override
+    protected void checkUpdate(UpdateContext context) {
+        super.checkUpdate(context);
+        for (Key value : Key.values()) {
+            if (context.updatedKeys().contains(value.name())) {
+                value.validator.accept(context.key(value.name()));
+            }
+        }
+        Optional<Integer> maxPoolSize = context.key(Key.steadypoolsize.name()).convertIfValid(Integer::parseInt);
+        Optional<Integer> steadyPoolSize = context.key(Key.steadypoolsize.name()).convertIfValid(Integer::parseInt);
+        if (maxPoolSize.isPresent() && steadyPoolSize.isPresent() && steadyPoolSize.get() > maxPoolSize.get()) {
+            context.addValidationError("Steady pool size much be smaller or equal to maxPoolSize");
+        }
+    }
+
+    private Optional<Key> find(String key) {
+        try {
+            return Optional.of(Key.valueOf(key));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+
+    enum Key {
+        steadypoolsize("1", Integer::parseInt, Key::assertNonNegative),
+        maxpoolsize("10", Integer::parseInt, Key::assertPositive),
+        maxwaittime("30000", Integer::parseInt, Key::assertPositive),
+        jdbcurl,
+        user,
+        password;
+
+        private final Optional<String> defaultValue;
+        Consumer<UpdateContext> validator;
+
+        Key() {
+            this.validator = (c) -> {};
+            this.defaultValue = Optional.empty();
+        }
+
+        Key(String defaultValue, Consumer<String> checkFunction) {
+            this.defaultValue = Optional.ofNullable(defaultValue);
+            this.validator = (c) -> c.check(checkFunction);
+        }
+
+        <T> Key(String defaultValue, Function<String, T> converter, Consumer<T> check) {
+            this.defaultValue = Optional.ofNullable(defaultValue);
+            this.validator = (c) -> c.convertAndCheck(converter, check);
+        }
+
+        boolean isRequired() {
+            return this != user && this != password;
+        }
+
+        private static void assertNonNegative(int value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException("Value must be non-negative integer");
+            }
+        }
+
+        private static void assertPositive(int value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException("Value must be non-negative integer");
+            }
+        }
+
+    }
+
+
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/datasource/DatasourceInspection.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/inspection/datasource/DatasourceInspection.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.inspection.datasource;
+
+import fish.payara.cloud.deployer.inspection.InspectedArtifact;
+import fish.payara.cloud.deployer.inspection.Inspection;
+import fish.payara.cloud.deployer.inspection.InspectionException;
+import fish.payara.cloud.deployer.utils.Xml;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.enterprise.context.Dependent;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+@Dependent
+class DatasourceInspection implements Inspection {
+    private Map<String, DatasourceConfiguration> configs = new HashMap<>();
+
+
+    @Override
+    public void inspect(ArtifactEntry entry, InspectedArtifact artifact) throws IOException {
+        if (entry.classpathMatches("META-INF/persistence.xml")) {
+            try {
+                parseJpa(entry.getInputStream());
+            } catch (SAXException | IllegalArgumentException e) {
+                throw new InspectionException("Cannot parse persistence.xml", e);
+            }
+        }
+    }
+
+    private void parseJpa(InputStream inputStream) throws IOException, SAXException {
+        var persistenceXml = Xml.parse(inputStream);
+        var persistenceUnits = Xml.xpath(persistenceXml, "/*[local-name()='persistence']/*[local-name() = 'persistence-unit']");
+        for (Node persistenceUnit : persistenceUnits) {
+            var ns = persistenceUnit.getNamespaceURI();
+            var name = Xml.attr(persistenceUnit, "name", null);
+            if (name == null) {
+                throw new IllegalArgumentException("Name of the persistence unit not specified");
+            }
+            var transactionType = Xml.attr(persistenceUnit, "transaction-type", "JTA");
+            var datasources = Xml.xpath(persistenceUnit, "*[local-name() = 'jta-data-source' or local-name()='non-jta-data-source']");
+            if (datasources.size() == 0 && "JTA".equals(transactionType)) {
+                addDefaultDatasourceConfig();
+            }
+            for (Node datasource : datasources) {
+                if ("jta-data-source".equals(datasource.getLocalName()) && "JTA".equals(transactionType)) {
+                    addJtaDatasourceConfig(datasource.getTextContent());
+                }
+                if ("non-jta-data-source".equals(datasource.getLocalName()) && "RESOURCE_LOCAL".equals(transactionType)) {
+                    addNonJtaDataSourceConfig(datasource.getTextContent());
+                }
+            }
+        }
+    }
+
+    private void addNonJtaDataSourceConfig(String jndiName) {
+        addDataSourceConfig(jndiName);
+    }
+
+    private void addDataSourceConfig(String jndiName) {
+        configs.computeIfAbsent(jndiName, DatasourceConfiguration::new);
+    }
+
+    private void addJtaDatasourceConfig(String jndiName) {
+        addDataSourceConfig(jndiName);
+    }
+
+    private void addDefaultDatasourceConfig() {
+        configs.computeIfAbsent(DatasourceConfiguration.DEFAULT_NAME, k -> DatasourceConfiguration.createDefault());
+    }
+
+
+    @Override
+    public void finish(InspectedArtifact artifact) {
+        configs.values().forEach(artifact::addConfiguration);
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ConfigBean.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ConfigBean.java
@@ -139,10 +139,10 @@ public class ConfigBean {
         configKind.put(domainObject.getId(), representation);
     }
 
-    private static Pattern POST_KEY = Pattern.compile("(.+?):(.+?):(.+)");
+    private static Pattern POST_KEY = Pattern.compile("(.+?):(.+?)::(.+)");
     
     public static String updateKeyFor(Configuration domainObject, String key) {
-        return domainObject.getKind() + ":" + domainObject.getId() + ":" + key;
+        return domainObject.getKind() + ":" + domainObject.getId() + "::" + key;
     }
     public void applyValuesFrom(Map<String, String> singleValues) {
         for (Map.Entry<String, String> entry : singleValues.entrySet()) {

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/Configuration.java
@@ -74,8 +74,8 @@ public abstract class Configuration {
      * @param id id of the configuration
      */
     protected Configuration(String id) {
-        if (id.contains(":")) {
-            throw new IllegalArgumentException("Invalid configuration id "+id+" name cannot contain colon");
+        if (id.contains("::")) {
+            throw new IllegalArgumentException("Invalid configuration id "+id+" name cannot contain double colon");
         }
         this.id = id;
     }
@@ -453,6 +453,13 @@ public abstract class Configuration {
          */
         public boolean isValid() {
             return validationErrors.isEmpty() && mainValidationError == null;
+        }
+
+        public <T> Optional<T> convertIfValid(Function<? super String, T> converter) {
+            if (validationContext == null || validationErrors.containsKey(validationContext)) {
+                return Optional.empty();
+            }
+            return getValue(validationContext).map(converter);
         }
     }
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/utils/Xml.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/utils/Xml.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.utils;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathNodes;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Xml {
+    private Xml() {
+
+    }
+
+    public static Document parse(InputStream inputStream) throws SAXException, IOException {
+        var dbf = DocumentBuilderFactory.newInstance();
+        dbf.setValidating(false);
+        dbf.setExpandEntityReferences(false);
+        dbf.setNamespaceAware(true);
+        try {
+            dbf.setFeature( "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            return dbf.newDocumentBuilder().parse(inputStream);
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("Cannot instantiate XML parser");
+        }
+    }
+
+    public static XPathNodes xpath(Document document, String xpath)  {
+        var factory = XPathFactory.newInstance();
+        try {
+            return factory.newXPath().evaluateExpression(xpath, document, XPathNodes.class);
+        } catch (XPathExpressionException e) {
+            throw new IllegalArgumentException("Invalid xpath query "+xpath, e);
+        }
+    }
+
+    public static XPathNodes xpath(Node document, String xpath)  {
+        var factory = XPathFactory.newInstance();
+        try {
+            return factory.newXPath().evaluateExpression(xpath, document, XPathNodes.class);
+        } catch (XPathExpressionException e) {
+            throw new IllegalArgumentException("Invalid xpath query "+xpath, e);
+        }
+    }
+
+    public static String attr(Node element, String attribute, String defaultValue) {
+        if (!element.hasAttributes()) {
+            return defaultValue;
+        }
+        var attr = element.getAttributes().getNamedItem(attribute);
+        return attr != null ? attr.getNodeValue() : defaultValue;
+    }
+
+    public static Node child(Node node, String ns, String elementName) {
+        if (!node.hasChildNodes()) {
+            return null;
+        }
+        var children = node.getChildNodes();
+        for (int i=0; i < children.getLength(); i++) {
+            var child = children.item(i);
+            if ((ns == null || ns.equals(child.getNamespaceURI())) && elementName.equals(child.getLocalName())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/inspection/datasource/DatasourceInspectionTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/inspection/datasource/DatasourceInspectionTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.inspection.datasource;
+
+import fish.payara.cloud.deployer.inspection.InspectedArtifact;
+import fish.payara.cloud.deployer.process.Configuration;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
+
+import static fish.payara.cloud.deployer.inspection.InspectionHelper.write;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DatasourceInspectionTest {
+    static final String SUN_NS = "http://java.sun.com/xml/ns/persistence";
+    static final String JCP_NS = "http://xmlns.jcp.org/xml/ns/persistence/";
+
+    @Test
+    public void defaultDatasourceIdentified() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit());
+        assertEquals("Without transaction-type and no jta-data-source, default datasource should be used", 1, configs.size());
+        var config = configs.get(0);
+        assertTrue(config.isComplete());
+    }
+
+    @Test
+    public void jtaDatasourceIdentified() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withJta());
+        assertEquals("Without transaction-type and with jta-data-source, jta datasource should be used", 1, configs.size());
+        var config = configs.get(0);
+        assertFalse(config.isComplete());
+    }
+
+    @Test
+    public void jtaDatasourceIdentifiedWithExplicitNamespace() throws IOException {
+        var namespacedXML = generate(SUN_NS, new Unit().withJta())
+                .replace("xmlns","xmlns:p")
+                .replaceAll("<(/?)(\\w)", "<$1p:$2");
+
+        var testFile = write(ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset(namespacedXML), "META-INF/persistence.xml"));
+        var configs = discoveredConfig("test", testFile);
+        assertEquals(1, configs.size());
+        var config = configs.get(0);
+        assertFalse(config.isComplete());
+    }
+
+
+    @Test
+    public void nonJtaDatasourceIdentified() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withNonJta().withTransactionType("RESOURCE_LOCAL"));
+        assertEquals("With resource local transaction type, non jta datasource should be used",1, configs.size());
+        var config = configs.get(0);
+        assertFalse(config.isComplete());
+    }
+
+    @Test
+    public void nonJtaWithoutResourceLocalNotIdentified() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withNonJta());
+        assertEquals("Without resource local transaction type and no jta datasource, no datasource should be configured", 0, configs.size());
+    }
+
+    @Test
+    public void resourceLocalWithoutNonJtaNotIdentified() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withTransactionType("RESOURCE_LOCAL"));
+        assertEquals("With resource local transaction type and no non-jta datasource, no datasource should be configured", 0, configs.size());
+    }
+
+    @Test
+    public void attributeDeterminesWhenBothTypesPresentDefault() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withJta().withNonJta());
+        assertEquals("When both datasources are specified, datasource should be picked", 1, configs.size());
+        var config = configs.get(0);
+        assertTrue("When no transaction type specified, jta datasource should be used", config.getId().endsWith("-jta"));
+    }
+
+    @Test
+    public void attributeDeterminesWhenBothTypesPresentJta() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withJta().withNonJta().withTransactionType("JTA"));
+        assertEquals("When both datasources are specified, datasource should be picked", 1, configs.size());
+        var config = configs.get(0);
+        assertTrue("When no transaction type specified, jta datasource should be used", config.getId().endsWith("-jta"));
+    }
+
+    @Test
+    public void attributeDeterminesWhenBothTypesPresentNonJta() throws IOException {
+        var configs = discoveredConfig(JCP_NS, new Unit().withJta().withNonJta().withTransactionType("RESOURCE_LOCAL"));
+        assertEquals("When both datasources are specified, datasource should be picked", 1, configs.size());
+        var config = configs.get(0);
+        assertTrue("When no transaction type specified, jta datasource should be used", config.getId().endsWith("-nonjta"));
+    }
+
+    @Test
+    public void multiplePersistenceUnitsWithDefaultDatasourceIdentified() throws IOException {
+        var conf = discoveredConfig(JCP_NS, new Unit(), new Unit());
+        assertEquals("One config per datasource should be found", 1, conf.size());
+    }
+
+    @Test
+    public void multiplePersistenceUnitsIdentified() throws IOException {
+        var conf = discoveredConfig(JCP_NS, new Unit().withJta(), new Unit().withNonJta());
+        assertEquals("One config per datasource should be found", 1, conf.size());
+    }
+
+    @Test
+    public void multiplePersistenceUnitsWithSingleDatasourceIdentified() throws IOException {
+        var conf = discoveredConfig(JCP_NS, new Unit().withJta("jdbc/main"), new Unit().withJta("jdbc/main"));
+        assertEquals("One config per datasource should be found", 1, conf.size());
+    }
+
+    @Test
+    public void jpa20namespaceIdentified() throws IOException {
+        var configs = discoveredConfig(SUN_NS, new Unit().withJta());
+        assertEquals(1, configs.size());
+        var config = configs.get(0);
+        assertFalse(config.isComplete());
+    }
+
+    static class Unit {
+        String name = UUID.randomUUID().toString();
+        String transactionType;
+        String jtaDatasourceName;
+        String nonJtaDatasourceName;
+
+        Unit withTransactionType(String transactionType) {
+            this.transactionType = transactionType;
+            return this;
+        }
+
+        Unit withJta() {
+            this.jtaDatasourceName = "jdbc/"+name+"-jta";
+            return this;
+        }
+
+        Unit withJta(String name) {
+            this.jtaDatasourceName = name;
+            return this;
+        }
+
+        Unit withNonJta() {
+            this.nonJtaDatasourceName = "jdbc/"+name+"-nonjta";
+            return this;
+        }
+    }
+
+    private List<Configuration> discoveredConfig(String namespace, Unit... units) throws IOException {
+        var testFile = write(ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset(generate(namespace, units)), "META-INF/persistence.xml"));
+        return discoveredConfig("test", testFile);
+    }
+
+
+    private String generate(String namespace, Unit... units) {
+        StringBuilder xmlBuilder = new StringBuilder("<?xml version='1.0'?>\n");
+        xmlBuilder.append("<persistence xmlns='").append(namespace).append("'>\n");
+        for (Unit unit : units) {
+            xmlBuilder.append("<persistence-unit name='").append(unit.name).append("'");
+            if (unit.transactionType != null) {
+                xmlBuilder.append(" transaction-type='").append(unit.transactionType).append("'");
+            }
+            xmlBuilder.append(">\n");
+            if (unit.jtaDatasourceName != null) {
+                xmlBuilder.append("  <jta-data-source>").append(unit.jtaDatasourceName).append("</jta-data-source>\n");
+            }
+            if (unit.nonJtaDatasourceName != null) {
+                xmlBuilder.append("  <non-jta-data-source>").append(unit.nonJtaDatasourceName).append("</non-jta-data-source>\n");
+            }
+            xmlBuilder.append("</persistence-unit>\n");
+        }
+        xmlBuilder.append("</persistence>");
+        return xmlBuilder.toString();
+    }
+
+    private List<Configuration> discoveredConfig(String name, File testFile) throws IOException {
+        var inspection = new DatasourceInspection();
+        var artifact = InspectedArtifact.inspect(name, new ZipFile(testFile), List.of(inspection));
+        return artifact.getConfigurations().stream().filter(c -> c.getKind().equals(DatasourceConfiguration.KIND))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
`persistence.xml` on main classpath (we're not scanning lib jars yet), is parsed and JNDI names of datasources the respective persistence units expect are captured in `DatasourceConfiguration`s.

Context root configuration constants have been changed to use camelCase and be consistent with other configurations.

It starts to show that we might need some better support for accessing and converting configuration values.