### PR TITLE
CLOUD-50: Cloud instance launcher

### DIFF
--- a/instance/launcher/pom.xml
+++ b/instance/launcher/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+  ~
+  ~  The contents of this file are subject to the terms of either the GNU
+  ~  General Public License Version 2 only ("GPL") or the Common Development
+  ~  and Distribution License("CDDL") (collectively, the "License").  You
+  ~  may not use this file except in compliance with the License.  You can
+  ~  obtain a copy of the License at
+  ~  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  ~  See the License for the specific
+  ~  language governing permissions and limitations under the License.
+  ~
+  ~  When distributing the software, include this License Header Notice in each
+  ~  file and include the License file at glassfish/legal/LICENSE.txt.
+  ~
+  ~  GPL Classpath Exception:
+  ~  The Payara Foundation designates this particular file as subject to the "Classpath"
+  ~  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  ~  file that accompanied this code.
+  ~
+  ~  Modifications:
+  ~  If applicable, add the following below the License Header, with the fields
+  ~  enclosed by brackets [] replaced by your own identifying information:
+  ~  "Portions Copyright [year] [name of copyright owner]"
+  ~
+  ~  Contributor(s):
+  ~  If you wish your version of this file to be governed by only the CDDL or
+  ~  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  ~  elects to include this software in this distribution under the [CDDL or GPL
+  ~  Version 2] license."  If you don't indicate a single choice of license, a
+  ~  recipient has the option to distribute your version of this file under
+  ~  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  ~  its licensees as provided above.  However, if you add GPL Version 2 code
+  ~  and therefore, elected the GPL Version 2 license, then the option applies
+  ~  only if the new code is made subject to such option by the copyright
+  ~  holder.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.cloud</groupId>
+        <artifactId>instance-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>launcher</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-micro</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <dependencyReducedPomLocation>${build.directory}/reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>fish.payara.cloud.instance.jackson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>fish.payara.cloud.instance.Main</mainClass>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>false</addHeader>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/Applicator.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/Applicator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance;
+
+import fish.payara.cloud.instance.applicator.CLIApplicator;
+import fish.payara.cloud.instance.applicator.CLIBootstrap;
+import fish.payara.cloud.instance.applicator.Repackager;
+import fish.payara.micro.boot.PayaraMicroBoot;
+import fish.payara.micro.boot.PayaraMicroLauncher;
+
+/**
+ * Apply configuration steps to Payara Micro instance.
+ *
+ * <p>Based on classpath constellation, different strategies need to be taken.</p>
+ */
+public interface Applicator {
+    /**
+     * Get applicator fit for current launch mode
+     * @return an instance
+     */
+    static Applicator getInstance() {
+        // API has limited configuration options, chiefly there's no access
+        // to preboot/postboot commands
+        //PayaraMicro.unpackJars();
+        //PayaraMicro.setUpackedJarDir();
+        //PayaraMicro instance = PayaraMicro.getInstance();
+
+        // Payara micro launcher gives us commands via command line arguments
+        CLIBootstrap bootstrap = PayaraMicroLauncher::create;
+
+        try {
+            var rootLauncher = Class.forName("fish.payara.micro.impl.RootDirLauncher");
+            var impl = Class.forName("fish.payara.micro.impl.PayaraMicroImpl");
+
+            // if these classes are on our classpath, that means we're in flat classloader and should
+            // utilize root launcher
+
+            var mainMethod = rootLauncher.getMethod("main", String[].class);
+            var instanceMethod = impl.getMethod("getInstance");
+
+            bootstrap = (args) -> {
+                mainMethod.invoke(null, (Object) args);
+                return (PayaraMicroBoot) instanceMethod.invoke(null);
+            };
+        } catch (ClassNotFoundException e) {
+            // we're not in flat classpath, previous bootstrap will work
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Payara Micro classes are not what I expect", e);
+        }
+        return new CLIApplicator(bootstrap);
+    }
+
+    static Repackager getRepackager() {
+        try {
+            // is there Micro on the classpath?
+            Class.forName("fish.payara.micro.boot.PayaraMicroLauncher");
+            return new Repackager(PayaraMicroLauncher::create);
+        } catch (ClassNotFoundException e) {
+            return new Repackager(null);
+        }
+    }
+
+    void addPreBootCommand(String command, String... arguments);
+
+    void addPostBootCommand(String command, String... arguments);
+
+    void addPostDeployCommand(String command, String... arguments);
+
+    default void addCommandlineArgument(String argument) {
+        addCommandlineArgument(argument, null);
+    }
+
+    default void addCommandlineArgument(String argument, String value) {
+        switch (argument) {
+            case "--deploy":
+            case "--deploymentdir":
+            case "--systemproperties":
+            case "--prebootcommandfile":
+            case "--postbootcommandfile":
+            case "--postdeploycommandfile":
+                throw new IllegalArgumentException("Use specialized command for "+argument);
+        }
+    }
+
+    void addDeployment(String artifact, String contextPath);
+
+    default void addDeployment(String artifact) {
+        addDeployment(artifact, null);
+    }
+
+    void addSystemProperty(String name, String value);
+
+    PayaraMicroBoot start() throws Exception;
+
+    PayaraMicroBoot getServer();
+
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/ConfigurationPlan.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/ConfigurationPlan.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance;
+
+import fish.payara.cloud.instance.tasks.ConfigurationTask;
+import fish.payara.cloud.instance.tasks.Deployment;
+import fish.payara.cloud.instance.tasks.TaskVisitor;
+import fish.payara.cloud.instance.tasks.value.FileValue;
+import fish.payara.cloud.instance.tasks.value.StringValue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Sequence of configuration tasks to be applied to an instance
+ * @see #plan(List)
+ */
+public class ConfigurationPlan {
+    private final List<ConfigurationTask> tasks;
+
+    private ConfigurationPlan(List<ConfigurationTask> tasks) {
+
+        this.tasks = tasks;
+    }
+
+    /**
+     * Process parsed configuration tasks, creating an ordered sequence of them
+     * @param tasks
+     * @return
+     */
+    public static ConfigurationPlan plan(List<ConfigurationTask> tasks) {
+        var sortedTasks = new ArrayList<>(tasks);
+        Collections.sort(sortedTasks, Comparator.comparingInt(ConfigurationTask::getPriority));
+
+        // apply any other inter-task rules
+        // (none right now)
+
+        var plan = new ConfigurationPlan(sortedTasks);
+        return plan;
+    }
+
+
+    /**
+     * Apply the plan via an applicator
+     * @param planApplicator
+     */
+    public void execute(Applicator planApplicator) {
+        var visitor = new Visitor(planApplicator);
+        tasks.forEach(task -> task.accept(visitor));
+    }
+
+    /**
+     * Visitor translates configuration tasks to applicator invocations.
+     */
+    class Visitor implements TaskVisitor {
+        private final Applicator applicator;
+
+        Visitor(Applicator applicator) {
+            this.applicator = applicator;
+        }
+
+        @Override
+        public void deployment(Deployment deployment) {
+            applicator.addDeployment(deployment.getArtifact().fileName(), deployment.getContextRoot().value());
+        }
+
+        @Override
+        public void microprofileConfigProperties(FileValue file) {
+            Properties p = new Properties();
+            try {
+                p.load(new StringReader(file.contents()));
+                p.entrySet().forEach(e -> applicator.addSystemProperty(e.getKey().toString(), e.getValue().toString()));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot read properties from "+file.fileName(), e);
+            }
+        }
+
+        @Override
+        public void microprofileConfigValues(Map<String, StringValue> map) {
+            map.entrySet().forEach(e -> applicator.addSystemProperty(e.getKey(), e.getValue().value()));
+        }
+    }
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/Main.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/Main.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance;
+
+import fish.payara.cloud.instance.tasks.ConfigurationTask;
+import fish.payara.cloud.instance.tasks.Serialization;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Entry point.
+ * Invoke with path to directory containing configuration tasks in json format.
+ */
+public class Main {
+    private final Path configRoot;
+
+    public Main(String configDir) {
+        this.configRoot = Path.of(configDir);
+    }
+
+    public static void main(String[] args) throws Exception {
+        if ("--outputlauncher".equals(args[0])) {
+            Applicator.getRepackager().packageTo(args[1]);
+        } else {
+            Main main = new Main(args[0]);
+            main.run();
+        }
+    }
+
+    private void run() throws Exception {
+        List<ConfigurationTask> tasks = parseConfig();
+        ConfigurationPlan plan = ConfigurationPlan.plan(tasks);
+        Applicator planApplicator = Applicator.getInstance();
+        plan.execute(planApplicator);
+        planApplicator.start();
+    }
+
+    private List<ConfigurationTask> parseConfig() throws IOException {
+        return Files.walk(configRoot)
+                .filter(p -> p.getFileName().toString().endsWith(".json"))
+                .map(Serialization::deserialize).collect(Collectors.toList());
+    }
+
+
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/applicator/CLIApplicator.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/applicator/CLIApplicator.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.applicator;
+
+import fish.payara.cloud.instance.Applicator;
+import fish.payara.micro.boot.PayaraMicroBoot;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static java.util.stream.Collectors.joining;
+
+public class CLIApplicator implements Applicator  {
+    private final CLIBootstrap bootstrap;
+
+    private List<Command> prebootCommands = new ArrayList<>();
+    private List<Command> postBootCommands = new ArrayList<>();
+    private List<Command> postDeployCommands = new ArrayList<>();
+    private List<Command> postBootstrapCommands = new ArrayList<>();
+
+    private Map<String,String> systemProperties = new HashMap<>();
+    private Map<String,String> deployments = new LinkedHashMap<>();
+    private List<String> arguments = new ArrayList<>();
+
+    static class Command {
+        List<String> contents;
+
+        public Command(String command, String ...arguments) {
+            contents = new ArrayList<>(arguments.length+1);
+            contents.add(command);
+            contents.addAll(Arrays.asList(arguments));
+        }
+    }
+
+    public CLIApplicator(CLIBootstrap bootstrap) {
+        this.bootstrap = bootstrap;
+    }
+
+    @Override
+    public void addPreBootCommand(String command, String... arguments) {
+        prebootCommands.add(new Command(command, arguments));
+    }
+
+    @Override
+    public void addPostBootCommand(String command, String... arguments) {
+        postBootCommands.add(new Command(command, arguments));
+    }
+
+    @Override
+    public void addPostDeployCommand(String command, String... arguments) {
+        postDeployCommands.add(new Command(command, arguments));
+    }
+
+    @Override
+    public void addCommandlineArgument(String argument, String value) {
+        Applicator.super.addCommandlineArgument(argument, value);
+        arguments.add(argument);
+        if (value != null) {
+            arguments.add(value);
+        }
+    }
+
+    @Override
+    public void addDeployment(String artifact, String contextPath) {
+        deployments.put(artifact, contextPath);
+    }
+
+    @Override
+    public void addSystemProperty(String name, String value) {
+        systemProperties.put(name, value);
+    }
+
+    @Override
+    public PayaraMicroBoot start() throws Exception {
+        List<String> completeArguments = new ArrayList<>();
+        completeArguments.addAll(renderPreboot());
+        completeArguments.addAll(renderPostboot());
+        completeArguments.addAll(renderPostdeploy());
+        completeArguments.addAll(renderSystemProperties());
+        completeArguments.addAll(renderDeployments());
+        completeArguments.addAll(arguments);
+        return bootstrap.bootstrap(completeArguments.toArray(String[]::new));
+    }
+
+    private Collection<String> renderPreboot() {
+        return renderScript("--prebootcommandfile", prebootCommands);
+    }
+
+    private Collection<String> renderPostboot() {
+        return renderScript("--postbootcommandfile", postBootCommands);
+    }
+
+    private Collection<String> renderPostdeploy() {
+        return renderScript("--postdeploycommandfile", postDeployCommands);
+    }
+
+    private Collection<String> renderSystemProperties() {
+        if (systemProperties.isEmpty()) {
+            return Collections.emptyList();
+        }
+        try (var file = new TempFile("systemprops")) {
+            var props = new Properties();
+            props.putAll(systemProperties);
+            props.list(file.writer);
+            return List.of("--systemproperties", file.filename());
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot write temp file", e);
+        }
+    }
+
+    private Collection<String> renderDeployments() {
+        var result = new ArrayList<String>();
+        for (Map.Entry<String, String> deployment : deployments.entrySet()) {
+            result.add("--deploy");
+            if (deployment.getValue() == null) {
+                result.add(deployment.getKey());
+            } else {
+                result.add(deployment.getKey()+File.pathSeparator+deployment.getValue());
+            }
+        }
+        return result;
+    }
+
+    private Collection<String> renderScript(String argument, List<Command> commands) {
+        if (commands.isEmpty()) {
+            return Collections.emptyList();
+        }
+        try (var file = new TempFile(argument.replaceAll("--",""))) {
+            commands.forEach(c -> file.println(c.contents.stream().collect(joining(" "))));
+            return List.of(argument, file.filename());
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot write temp file", e);
+        }
+    }
+
+
+    static class TempFile implements AutoCloseable {
+        private final File file;
+        private final PrintWriter writer;
+
+        TempFile(String prefix) throws IOException {
+            file = File.createTempFile(prefix, "");
+            writer = new PrintWriter(new FileWriter(file, StandardCharsets.UTF_8));
+        }
+
+        void println(String s) {
+            writer.println(s);
+        }
+
+        String filename() {
+            return file.getAbsolutePath();
+        }
+
+        @Override
+        public void close() {
+            writer.close();
+        }
+    }
+
+    @Override
+    public PayaraMicroBoot getServer() {
+        return null;
+    }
+
+}
+

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/applicator/CLIBootstrap.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/applicator/CLIBootstrap.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.applicator;
+
+import fish.payara.micro.boot.PayaraMicroBoot;
+
+@FunctionalInterface
+public interface CLIBootstrap {
+    PayaraMicroBoot bootstrap(String[] args) throws Exception;
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/applicator/Repackager.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/applicator/Repackager.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.applicator;
+
+import fish.payara.cloud.instance.Main;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSource;
+import java.util.ArrayList;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+public class Repackager {
+    private final CLIBootstrap bootstrap;
+
+    public Repackager(CLIBootstrap bootstrap) {
+        this.bootstrap = bootstrap;
+    }
+
+    public void packageTo(String rootDir) throws Exception {
+        var arguments = new ArrayList<String>();
+        var root = Files.createDirectories(Path.of(rootDir));
+
+        if (bootstrap != null) {
+            arguments.add("--rootdir");
+            arguments.add(rootDir);
+            arguments.add("--outputlauncher");
+
+            bootstrap.bootstrap(arguments.toArray(String[]::new));
+        } else if (!Files.exists(root.resolve("launch-micro.jar"))) {
+            throw new IllegalArgumentException(rootDir + " is not Payara Micro directory with version and no " +
+                    "Micro is available on classpath");
+        }
+
+        try (var launchMicro = new JarFile(root.resolve("launch-micro.jar").toFile())) {
+            var sourceAttr = launchMicro.getManifest().getMainAttributes();
+            var targetManifest = new Manifest();
+            targetManifest.getMainAttributes().putAll(sourceAttr);
+            var targetAttr = targetManifest.getMainAttributes();
+            targetAttr.putValue("Main-Class", Main.class.getName());
+            targetAttr.putValue("Class-Path", "launch-micro.jar " + sourceAttr.getValue("Class-Path"));
+            try (var cloudInstance = new JarOutputStream(
+                    new FileOutputStream(root.resolve("cloud-instance.jar").toFile()), targetManifest);
+                 var self = new JarFile(launcherJar().toFile())) {
+
+                self.stream().filter(entry -> !entry.getName().equals("META-INF/MANIFEST.MF"))
+                        .forEach(entry -> {
+                            try {
+                                cloudInstance.putNextEntry(entry);
+                                try (InputStream input = self.getInputStream(entry)) {
+                                    byte[] buffer = new byte[4096];
+                                    for (int read = 0; (read = input.read(buffer)) > 0; ) {
+                                        cloudInstance.write(buffer, 0, read);
+                                    }
+                                }
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+            }
+        }
+    }
+
+    private Path launcherJar() {
+        var protectionDomain = Repackager.class.getProtectionDomain();
+        CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource != null) {
+            try {
+                return Path.of(codeSource.getLocation().toURI());
+            } catch (URISyntaxException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        throw new IllegalStateException("Cannot determine jar of cloud launcher");
+    }
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/ConfigurationTask.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/ConfigurationTask.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * A configuration task to apply to an instance.
+ *
+ * <p>Subclasses of this class represent a configuration (such as deployment, microprofile config override
+ * or datasource definition) that can be applied to an instance</p>
+ *
+ * <p>Tasks support JSON serialization via Jackson.</p>
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes({
+        @JsonSubTypes.Type(Deployment.class),
+        @JsonSubTypes.Type(MicroprofileConfigProperties.class)
+})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class ConfigurationTask {
+    public abstract void accept(TaskVisitor visitor);
+
+    @JsonIgnore
+    public int getPriority() {
+        return 0;
+    }
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/Deployment.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/Deployment.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import fish.payara.cloud.instance.tasks.value.FileValue;
+import fish.payara.cloud.instance.tasks.value.StringValue;
+
+
+@JsonTypeName("deployment")
+public class Deployment extends ConfigurationTask {
+    private StringValue contextRoot;
+    private FileValue artifact;
+
+    public StringValue getContextRoot() {
+        return contextRoot;
+    }
+
+    public void setContextRoot(StringValue contextRoot) {
+        this.contextRoot = contextRoot;
+    }
+
+    public FileValue getArtifact() {
+        return artifact;
+    }
+
+    public void setArtifact(FileValue artifact) {
+        this.artifact = artifact;
+    }
+
+    @Override
+    public void accept(TaskVisitor visitor) {
+        visitor.deployment(this);
+    }
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/MicroprofileConfigProperties.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/MicroprofileConfigProperties.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks;
+
+import fish.payara.cloud.instance.tasks.value.FileValue;
+import fish.payara.cloud.instance.tasks.value.StringValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Map;
+
+@JsonTypeName("mpConfig")
+public class MicroprofileConfigProperties extends ConfigurationTask {
+    private FileValue file;
+    private Map<String,StringValue> map;
+
+    public FileValue getFile() {
+        return file;
+    }
+
+    public void setFile(FileValue file) {
+        this.file = file;
+    }
+
+    public Map<String, StringValue> getMap() {
+        return map;
+    }
+
+    public void setMap(Map<String, StringValue> map) {
+        this.map = map;
+    }
+
+    @Override
+    public void accept(TaskVisitor visitor) {
+        if (file != null) {
+            visitor.microprofileConfigProperties(file);
+        } else {
+            visitor.microprofileConfigValues(map);
+        }
+    }
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/Serialization.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/Serialization.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class Serialization {
+    private final static ObjectMapper mapper;
+
+    static {
+        mapper = new ObjectMapper();
+    }
+
+    public static <T extends ConfigurationTask> T deserialize(Path file, Class<T> expectedClass) {
+        var values = new InjectableValues.Std();
+        values.addValue("fileContext", file);
+        values.addValue(Path.class, file);
+        try {
+            return mapper.readerFor(expectedClass).with(values).readValue(file.toFile());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not read "+file, e);
+        }
+    }
+
+    public static ConfigurationTask deserialize(Path file) {
+        return deserialize(file, ConfigurationTask.class);
+    }
+
+    public static String serialize(ConfigurationTask task) {
+        try {
+            return mapper.writeValueAsString(task);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Could not serialize", e);
+        }
+    }
+
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/TaskVisitor.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/TaskVisitor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks;
+
+import fish.payara.cloud.instance.tasks.value.FileValue;
+import fish.payara.cloud.instance.tasks.value.StringValue;
+
+import java.util.Map;
+
+public interface TaskVisitor {
+    void deployment(Deployment deployment);
+
+    void microprofileConfigProperties(FileValue file);
+
+    void microprofileConfigValues(Map<String, StringValue> map);
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/FileValue.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/FileValue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks.value;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(using = FileValueUnion.Deserializer.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface FileValue {
+    String fileName();
+    String contents();
+
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/FileValueUnion.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/FileValueUnion.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks.value;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * File value. One of following ways of defining a file can be chosen:
+ *
+ * <p>Literal value is interpreted as file path relative to defining configuration file</p>
+ * <p>Property {@link #getPath() path} evaluates file path as a {@link StringValueUnion}</p>
+ * <p>Property {@link #getHttpGet() httpGet} will download the file via HTTP</p>
+ */
+@JsonDeserialize(using = JsonDeserializer.None.class)
+public class FileValueUnion implements FileValue {
+    private String file;
+
+    private Path fileContext;
+
+    private StringValue path;
+    private StringValue httpGet;
+
+    @JsonIgnore
+    private FileValue delegate;
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public Path getFileContext() {
+        return fileContext;
+    }
+
+    @JacksonInject("fileContext")
+    public void setFileContext(Path fileContext) {
+        this.fileContext = fileContext;
+    }
+
+    public StringValue getPath() {
+        return path;
+    }
+
+    public void setPath(StringValue path) {
+        this.path = path;
+    }
+
+    public StringValue getHttpGet() {
+        return httpGet;
+    }
+
+    public void setHttpGet(StringValue httpGet) {
+        this.httpGet = httpGet;
+    }
+
+    public String fileName() {
+        return delegate().fileName();
+    }
+
+    public String contents() {
+        return delegate().contents();
+    }
+
+    private FileValue delegate() {
+        if (delegate == null) {
+            var options = Stream.of(file, path, httpGet).filter(c -> c != null).count();
+            if (options != 1) {
+                throw new IllegalArgumentException("Zero or more than one value specified");
+            }
+            if (file != null) {
+                delegate = new LocalFile(file, fileContext);
+            } else if (path != null) {
+                delegate = new LocalFile(path.value(), fileContext);
+            } else if (httpGet != null) {
+                delegate = new RemoteFile(httpGet.value());
+            }
+        }
+        return delegate;
+    }
+
+    static class LocalFile implements FileValue {
+        private final String path;
+        private final Path context;
+
+        LocalFile(String path, Path context) {
+            this.path = path;
+            this.context = context;
+        }
+
+        @Override
+        public String fileName() {
+            return resolve().toAbsolutePath().toString();
+        }
+
+        private Path resolve() {
+            return context.resolveSibling(path);
+        }
+
+        @Override
+        public String contents() {
+            try {
+                return Files.readString(resolve());
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot read referenced file", e);
+            }
+
+        }
+    }
+
+    static class RemoteFile implements FileValue {
+
+        private final String uri;
+
+        public RemoteFile(String uri) {
+            this.uri = uri;
+        }
+
+        @Override
+        public String fileName() {
+            throw new UnsupportedOperationException("Not yet supported");
+        }
+
+        @Override
+        public String contents() {
+            throw new UnsupportedOperationException("Not yet supported");
+        }
+    }
+
+    static class Deserializer extends StdDeserializer<FileValueUnion> {
+        static JavaType type = TypeFactory.defaultInstance().constructType(FileValueUnion.class);
+
+        public Deserializer() {
+            super(FileValueUnion.class);
+        }
+
+        @Override
+        public FileValueUnion deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            if (p.currentToken() == JsonToken.VALUE_STRING) {
+                FileValueUnion result = new FileValueUnion();
+                result.setFile(p.getText());
+                result.setFileContext((Path) ctxt.findInjectableValue("fileContext", null, null));
+                return result;
+            } else {
+                return (FileValueUnion) ctxt.findRootValueDeserializer(type).deserialize(p, ctxt);
+            }
+        }
+    }
+
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/StringValue.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/StringValue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks.value;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(as = StringValueUnion.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public interface StringValue {
+
+    String value();
+}

--- a/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/StringValueUnion.java
+++ b/instance/launcher/src/main/java/fish/payara/cloud/instance/tasks/value/StringValueUnion.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks.value;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+/**
+ * String value. One of following options can be used to specify the value:
+ * <p>Literal value is a string constant</p>
+ * <p>Property {@link #getFile() file} defines a file, contents of which will be used as value</p>
+ * <p>Property {@link #getPropertyFile() propertyFile} will read specified key in a property file.
+ * Property file needs to specify {@link PropertyValue#getFile() file} -- the property file and
+ * {@link PropertyValue#getKey() key} -- the key to read.</p>
+ */
+public class StringValueUnion implements StringValue {
+    private String literal;
+
+    private FileValue file;
+    private PropertyValue propertyFile;
+
+
+    public String getLiteral() {
+        return literal;
+    }
+
+    public void setLiteral(String literal) {
+        this.literal = literal;
+    }
+
+    public FileValue getFile() {
+        return file;
+    }
+
+    public void setFile(FileValue file) {
+        this.file = file;
+    }
+
+    public PropertyValue getPropertyFile() {
+        return propertyFile;
+    }
+
+    public void setPropertyFile(PropertyValue propertyFile) {
+        this.propertyFile = propertyFile;
+    }
+
+    public String value() {
+        var numSpecified = Stream.of(literal, file, propertyFile).filter(o -> o!= null).count();
+        if (numSpecified != 1) {
+            throw new IllegalArgumentException("Value not specified (or overspecified)");
+        }
+        if (literal != null) {
+            return literal;
+        } else if (file != null) {
+            return file.contents();
+        } else if (propertyFile != null) {
+            return propertyFile.value();
+        }
+        throw new AssertionError("Unreachable statement");
+    }
+
+    @JsonCreator
+    public static StringValueUnion fromString(String literal) {
+        StringValueUnion result = new StringValueUnion();
+        result.setLiteral(literal);
+        return result;
+    }
+
+    public static class PropertyValue {
+        private FileValue file;
+        private StringValue key;
+        private StringValue format;
+
+        public FileValue getFile() {
+            return file;
+        }
+
+        public void setFile(FileValue file) {
+            this.file = file;
+        }
+
+        public StringValue getKey() {
+            return key;
+        }
+
+        public void setKey(StringValue key) {
+            this.key = key;
+        }
+
+        public StringValue getFormat() {
+            return format;
+        }
+
+        public void setFormat(StringValue format) {
+            this.format = format;
+        }
+
+        public String value() {
+            if (format == null) {
+                format = StringValueUnion.fromString("property");
+            }
+            switch (format.value()) {
+                case "property":
+                    return propertyValue();
+                default:
+                    throw new IllegalArgumentException("Unsupported property file format "+format.value());
+            }
+        }
+
+        private String propertyValue() {
+            Properties prop = new Properties();
+            try (var reader = new FileReader(file.fileName(), StandardCharsets.UTF_8)) {
+                prop.load(reader);
+                var actualKey = key.value();
+                if (!prop.containsKey(actualKey)) {
+                    throw new IllegalArgumentException("Key "+actualKey+" in not present in "+file.fileName());
+                }
+                return prop.getProperty(key.value());
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot read "+file.fileName(), e);
+            }
+        }
+    }
+
+    public static StringValueUnion literal(String literal) {
+        StringValueUnion result = new StringValueUnion();
+        result.literal = literal;
+        return result;
+    }
+}

--- a/instance/launcher/src/test/java/fish/payara/cloud/instance/tasks/DeserializationTest.java
+++ b/instance/launcher/src/test/java/fish/payara/cloud/instance/tasks/DeserializationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.instance.tasks;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeserializationTest {
+
+    static final Path root = Path.of("src/test/payloads/");
+
+    private <T extends ConfigurationTask> T deserialize(String file, Class<T> resultClass) {
+        var result = Serialization.deserialize(root.resolve(file));
+        assertEquals(resultClass, result.getClass());
+        return resultClass.cast(result);
+    }
+
+    private String fileName(String relativePath) {
+        return root.resolve(relativePath).toAbsolutePath().toString();
+    }
+
+    @Test
+    public void simpleDeployment() {
+        var value = deserialize("deployment-constants.json", Deployment.class);
+        assertEquals("/", value.getContextRoot().value());
+        assertEquals(fileName("test.war"), value.getArtifact().fileName());
+    }
+
+    @Test
+    public void fileReference() {
+        // context root is in contents of file
+        var value = deserialize("deployment-filereference.json", Deployment.class);
+        assertEquals("indirectValue", value.getContextRoot().value());
+    }
+
+    @Test
+    public void propertyReference() {
+        // context root is a value in a property file
+        var value = deserialize("deployment-propertyreference.json", Deployment.class);
+        assertEquals("propertyValue", value.getContextRoot().value());
+    }
+
+    @Test
+    public void fileIndirectReference() {
+        // context root is in file listed as a value of a property file
+        var value = deserialize("deployment-complexreference.json", Deployment.class);
+        assertEquals("indirectValue", value.getContextRoot().value());
+    }
+
+    @Test
+    public void mpConfigFile() {
+        var value = deserialize("mp-config-file.json", MicroprofileConfigProperties.class);
+        assertEquals(fileName("valueInFile"), value.getFile().fileName());
+    }
+
+    @Test
+    public void mpConfigMap() {
+        var value = deserialize("mp-config-map.json", MicroprofileConfigProperties.class);
+        var map = value.getMap();
+        assertEquals("constantValue", map.get("constant").value());
+        assertEquals("valueInFile", map.get("fileRef").value());
+        assertEquals("propertyValue", map.get("propertyRef").value());
+    }
+
+}

--- a/instance/launcher/src/test/payloads/deployment-complexreference.json
+++ b/instance/launcher/src/test/payloads/deployment-complexreference.json
@@ -1,0 +1,15 @@
+{
+  "deployment": {
+    "contextRoot": {
+      "file": {
+        "path": {
+          "propertyFile": {
+            "file": "valueInFile",
+            "key": "indirectFilename"
+          }
+        }
+      }
+    },
+    "artifact": "test.war"
+  }
+}

--- a/instance/launcher/src/test/payloads/deployment-constants.json
+++ b/instance/launcher/src/test/payloads/deployment-constants.json
@@ -1,0 +1,6 @@
+{
+  "deployment": {
+    "contextRoot": "/",
+    "artifact": "test.war"
+  }
+}

--- a/instance/launcher/src/test/payloads/deployment-constants.xml
+++ b/instance/launcher/src/test/payloads/deployment-constants.xml
@@ -1,0 +1,5 @@
+<!-- Originally I wanted XML structure like this, Jackson fais to deserialize that -->
+<deployment>
+    <contextRoot>/</contextRoot>
+    <artifact>test.war</artifact>
+</deployment>

--- a/instance/launcher/src/test/payloads/deployment-filereference.json
+++ b/instance/launcher/src/test/payloads/deployment-filereference.json
@@ -1,0 +1,8 @@
+{
+  "deployment": {
+    "contextRoot": {
+      "file": "indirectReference"
+    },
+    "artifact": "test.war"
+  }
+}

--- a/instance/launcher/src/test/payloads/deployment-propertyreference.json
+++ b/instance/launcher/src/test/payloads/deployment-propertyreference.json
@@ -1,0 +1,11 @@
+{
+  "deployment": {
+    "contextRoot": {
+      "propertyFile": {
+        "file": "valueInFile",
+        "key": "indirectValue"
+      }
+    },
+    "artifact": "test.war"
+  }
+}

--- a/instance/launcher/src/test/payloads/indirectReference
+++ b/instance/launcher/src/test/payloads/indirectReference
@@ -1,0 +1,1 @@
+indirectValue

--- a/instance/launcher/src/test/payloads/mp-config-file.json
+++ b/instance/launcher/src/test/payloads/mp-config-file.json
@@ -1,0 +1,5 @@
+{
+  "mpConfig": {
+    "file": "valueInFile"
+  }
+}

--- a/instance/launcher/src/test/payloads/mp-config-map.json
+++ b/instance/launcher/src/test/payloads/mp-config-map.json
@@ -1,0 +1,16 @@
+{
+  "mpConfig": {
+    "map": {
+      "constant": "constantValue",
+      "fileRef": {
+        "file": "value"
+      },
+      "propertyRef": {
+        "propertyFile": {
+          "file": "valueInFile",
+          "key": "indirectValue"
+        }
+      }
+    }
+  }
+}

--- a/instance/launcher/src/test/payloads/samplerun/config.json
+++ b/instance/launcher/src/test/payloads/samplerun/config.json
@@ -1,0 +1,7 @@
+{
+  "mpConfig": {
+    "map": {
+      "fish.payara.talk.replicationtrouble.contentauthz.user.replication.ReplicationAPI/mp-rest/url": "/producer-app/replication"
+    }
+  }
+}

--- a/instance/launcher/src/test/payloads/samplerun/deploy.json
+++ b/instance/launcher/src/test/payloads/samplerun/deploy.json
@@ -1,0 +1,6 @@
+{
+  "deployment": {
+    "contextRoot": "/",
+    "artifact": "/src/zeromagic/talks/replication/consumer-app/target/consumer-app.war"
+  }
+}

--- a/instance/launcher/src/test/payloads/value
+++ b/instance/launcher/src/test/payloads/value
@@ -1,0 +1,1 @@
+valueInFile

--- a/instance/launcher/src/test/payloads/valueInFile
+++ b/instance/launcher/src/test/payloads/valueInFile
@@ -1,0 +1,2 @@
+indirectFilename=indirectReference
+indirectValue=propertyValue

--- a/instance/pom.xml
+++ b/instance/pom.xml
@@ -49,5 +49,6 @@
 
     <modules>
         <module>cds</module>
+        <module>launcher</module>
     </modules>
 </project>


### PR DESCRIPTION
Use to modify Payara Micro root directory with different main class.

Configuration can be specified as directory of json files passed
to Main class.

To create a launcher, first create Payara Micro launcher into a root directory and then invoke
```
java -jar launcher.jar --ouputlauncher $rootDir
```

An instance is then configured by pointing it to a directory that contains JSON configuration files. All levels of directories are scanned.
It is expected that these files will be distributed as config maps in Kubernetes cluster mounted into common top directory. The instance can be then launched with

```
java -jar $rootDir/cloud-instance.jar $configDir
```

Currently `deployment` and `mpConfig` tasks are implemented, more are expected (datasource configuration, cloud-platform specific logging,...)