### PR TITLE
CLOUD-53: Provision datasource

### DIFF
--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/NamespaceResource.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/endpoints/NamespaceResource.java
@@ -45,8 +45,7 @@ package fish.payara.cloud.deployer.endpoints;
 import fish.payara.cloud.deployer.process.Namespace;
 import fish.payara.cloud.deployer.provisioning.DeploymentInfo;
 import fish.payara.cloud.deployer.provisioning.Provisioner;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.Controller;
@@ -55,13 +54,19 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.RedirectionException;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
  * @author jonathan coustick
  */
-@Path("/namespaces")
+@Path("/namespaces/")
 @ApplicationScoped
 public class NamespaceResource {
     
@@ -83,7 +88,11 @@ public class NamespaceResource {
     @GET
     @Produces(MediaType.TEXT_HTML)
     @Controller
-    public String getNamespaces() {
+    public String getNamespaces(@Context UriInfo uriInfo) {
+        if (!uriInfo.getRequestUri().toString().endsWith("/")) {
+            // there are relative links in the view, so we need to be at /namespaces/ for the to work
+            throw new RedirectionException(Response.Status.MOVED_PERMANENTLY, uriInfo.getRequestUri().resolve("namespaces/"));
+        }
         model.put("title", "Namespaces");
         model.put("namespaces", getAllNamespaces().stream().collect(Collectors.groupingBy(Namespace::getStage)));
         return "namespaces.xhtml";

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DatasourcePostbootCommands.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/DatasourcePostbootCommands.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import fish.payara.cloud.deployer.inspection.datasource.DatasourceConfiguration;
+import fish.payara.cloud.deployer.process.Configuration;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+class DatasourcePostbootCommands {
+    private final StringBuilder postboot = new StringBuilder();
+
+    public void addDatasource(Configuration dsConfig) {
+        var values = DatasourceConfiguration.Value.forConfiguration(dsConfig);
+        postboot.append("create-jdbc-connection-pool")
+                .append(" --datasourceclassname ")
+                .append(values.datasourceClass())
+                .append(" --restype ")
+                .append(values.resourceType())
+                .append(" --steadypoolsize ")
+                .append(values.steadyPoolSize())
+                .append(" --maxpoolsize ")
+                .append(values.maxPoolSize())
+                .append(" --maxwait ")
+                .append(values.maxWaitTime())
+                .append(" --property ")
+                .append("url=")
+                .append(escapeProperty(values.jdbcUrl()));
+
+        if (values.user().isPresent()) {
+            postboot.append(":user=")
+                    .append(escapeProperty(values.user().get()));
+        }
+        if (values.password().isPresent()) {
+            postboot.append(":password=")
+                    .append(escapeProperty(values.password().get()));
+        }
+        postboot.append(" ")
+                .append(values.poolName())
+                .append("\n");
+
+        if (dsConfig.getId().equals(DatasourceConfiguration.DEFAULT_NAME)) {
+            postboot.append("set resources.jdbc-resource.jdbc/__default.pool-name=")
+                    .append(values.poolName());
+        } else {
+            postboot.append("create-jdbc-resource")
+                    .append(" --connectionpoolid ")
+                    .append(dsConfig.getId())
+                    .append("\n");
+        }
+    }
+
+    static String escapeProperty(String jdbcUrl) {
+        return jdbcUrl.replaceAll("([=:\\\\])","\\\\$1");
+    }
+
+    @Override
+    public String toString() {
+        return this.postboot.toString();
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ConfigBean.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/ConfigBean.java
@@ -258,6 +258,9 @@ public class ConfigBean {
         }
 
         private void updateValue(String key, String value) {
+            if (value != null && value.isBlank()) {
+                value = null;
+            }
             if (Objects.equals(value, values.get(key))) {
                 return;
             }

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/process/DeploymentProcessState.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import javax.json.bind.annotation.JsonbPropertyOrder;
 import javax.json.bind.annotation.JsonbTransient;
 import javax.json.bind.annotation.JsonbTypeAdapter;
@@ -279,6 +280,10 @@ public class DeploymentProcessState {
         return findConfiguration(kind, getName());
     }
 
+    public Stream<Configuration> findConfigurations(String kind) {
+        return configurations.stream().filter(c -> c.getKind().equals(kind));
+    }
+
     public boolean hasConfiguration(String kind, String id) {
         return findConfiguration(kind, id).isPresent();
     }
@@ -288,7 +293,7 @@ public class DeploymentProcessState {
     }
 
     public boolean hasConfigurationOverrides(String kind) {
-        return findConfiguration(kind).map(Configuration::hasOverrides).orElse(false);
+        return findConfigurations(kind).anyMatch(Configuration::hasOverrides);
     }
     
     StateChanged transition(ChangeKind target) {

--- a/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/deployment.yaml
+++ b/deployer/deployment-controller/src/main/resources/kubernetes/templates-direct/deployment.yaml
@@ -34,6 +34,10 @@ spec:
         app.kubernetes.io/managed-by: payara-cloud   
       annotations:
         payara.cloud/artifact-url: $(URL)
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: "http"
     spec:
       initContainers:
         - name: download-app

--- a/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment_list.xhtml
+++ b/deployer/deployment-controller/src/main/webapp/WEB-INF/views/deployment_list.xhtml
@@ -51,8 +51,8 @@
                     <li><h:outputLink value="${ingress}">${ingress}</h:outputLink></li>
                 </c:forEach>
                 </ul>
-                <form action="#{mvc.uri('DeploymentResource#deleteDeploymentViaForm', {'id' : deployment.id})}" method="post">
-                    <button style="float:right">Delete</button>
+                <form action="#{mvc.uri('DeploymentResource#deleteDeploymentViaForm', {'id' : deployment.id})}" method="post" style="text-align:right">
+                    <button>Delete</button>
                 </form>
             </section>
             </c:forEach>

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/DatasourcePostbootCommandsTest.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/DatasourcePostbootCommandsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatasourcePostbootCommandsTest {
+    @Test
+    public void testEscaping() {
+        assertEquals("jdbc\\://server.somewhere\\:1180;mode\\=ORACLE;log\\=c\\:\\\\log", DatasourcePostbootCommands.escapeProperty("jdbc://server.somewhere:1180;mode=ORACLE;log=c:\\log"));
+    }
+}


### PR DESCRIPTION
a8e8063 Implements the provisioning, the rest of the commits are small papercuts that I've hit during the development.

So far the datasource provisioning is brute-forced - since we know that there are no other requirements for postboot file, one is created if one or more datasources are configured in the app. `DatasourcePostbootCommands` is used to create the contents of this file.

A trivial typesafe proxy was created for `DatasourceConfiguration`, we'll likely need to better separate the storage and mechanics of updates, validation and usage of configuration data. But that requires doing persistence first.