### PR TITLE
CLOUD-23: Custom resource for webapp

### DIFF
--- a/deployer/deployment-controller/pom.xml
+++ b/deployer/deployment-controller/pom.xml
@@ -131,7 +131,6 @@
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
             <artifactId>payara-micro-remote</artifactId>
-            <!-- ECOSYS-86 -->
             <version>2.1</version>
         </dependency>
 
@@ -157,6 +156,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.15.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/DoneableWebApp.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/DoneableWebApp.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+public class DoneableWebApp extends CustomResourceDoneable<WebAppCustomResource> {
+    public DoneableWebApp(WebAppCustomResource resource, Function<WebAppCustomResource, WebAppCustomResource> function) {
+        super(resource, function);
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppCustomResource.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppCustomResource.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public class WebAppCustomResource extends CustomResource {
+    public static final String CRD_GROUP = "payara.cloud";
+    public static final String CRD_NAME = "webapps."+CRD_GROUP;
+    public static final String KIND = "WebApp";
+    public static final String VERSION = "v1beta1";
+
+    private WebAppSpec spec = new WebAppSpec();
+    private WebAppStatus status;
+
+    public WebAppCustomResource() {
+        super(KIND);
+    }
+
+    protected WebAppCustomResource(String customKind) {
+        super(customKind);
+    }
+
+
+    public WebAppSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(WebAppSpec spec) {
+        this.spec = spec;
+    }
+
+    public WebAppStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(WebAppStatus status) {
+        this.status = status;
+    }
+
+    public WebAppStatus makeStatus() {
+        if (status == null) {
+            setStatus(new WebAppStatus());
+        }
+        status.setObservedGeneration(getMetadata().getGeneration());
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return "WebAppCustomResource{" +
+                "metadata=" + getMetadata() +
+                "spec=" + spec +
+                '}';
+    }
+
+    public static void register() {
+        KubernetesDeserializer.registerCustomKind(CRD_GROUP + "/" + VERSION, "WebApp", WebAppCustomResource.class);
+    }
+
+    public static CustomResourceDefinition findDefinition(KubernetesClient client) {
+        return client.customResourceDefinitions().withName(CRD_NAME).get();
+    }
+
+    // Wonderful return type
+    public static MixedOperation<WebAppCustomResource, WebAppList, DoneableWebApp, Resource<WebAppCustomResource, DoneableWebApp>> client(KubernetesClient client, CustomResourceDefinition definition) {
+        return client.customResources(definition, WebAppCustomResource.class, WebAppList.class, DoneableWebApp.class);
+    }
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppList.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppList.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class WebAppList extends CustomResourceList<WebAppCustomResource> {
+}

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppSpec.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppSpec.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WebAppSpec {
+    private URI artifactUrl;
+
+    private List<WebAppSpecConfiguration> _configuration = null;
+
+    private UUID deploymentProcessId;
+
+
+    public WebAppSpec artifactUrl(URI artifactUrl) {
+        this.artifactUrl = artifactUrl;
+        return this;
+    }
+
+    public URI getArtifactUrl() {
+        return artifactUrl;
+    }
+
+    public void setArtifactUrl(URI artifactUrl) {
+        this.artifactUrl = artifactUrl;
+    }
+
+
+    public WebAppSpec _configuration(List<WebAppSpecConfiguration> _configuration) {
+
+        this._configuration = _configuration;
+        return this;
+    }
+
+    public WebAppSpec addConfigurationItem(WebAppSpecConfiguration _configurationItem) {
+        if (this._configuration == null) {
+            this._configuration = new ArrayList<>();
+        }
+        this._configuration.add(_configurationItem);
+        return this;
+    }
+
+    public WebAppSpec addConfigurationItem(String kind, String id, Map<String,String> values) {
+        var config = new WebAppSpecConfiguration();
+        config.setKind(kind);
+        config.setId(id);
+        config.setValues(values);
+        return addConfigurationItem(config);
+    }
+
+    public List<WebAppSpecConfiguration> getConfiguration() {
+        return _configuration;
+    }
+
+
+    public void setConfiguration(List<WebAppSpecConfiguration> _configuration) {
+        this._configuration = _configuration;
+    }
+
+
+    public WebAppSpec deploymentProcessId(UUID deploymentProcessId) {
+
+        this.deploymentProcessId = deploymentProcessId;
+        return this;
+    }
+
+    public UUID getDeploymentProcessId() {
+        return deploymentProcessId;
+    }
+
+
+    public void setDeploymentProcessId(UUID deploymentProcessId) {
+        this.deploymentProcessId = deploymentProcessId;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WebAppSpec webAppSpec = (WebAppSpec) o;
+        return Objects.equals(this.artifactUrl, webAppSpec.artifactUrl) &&
+                Objects.equals(this._configuration, webAppSpec._configuration) &&
+                Objects.equals(this.deploymentProcessId, webAppSpec.deploymentProcessId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(artifactUrl, _configuration, deploymentProcessId);
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class WebAppSpec {\n");
+        sb.append("    artifactUrl: ").append(toIndentedString(artifactUrl)).append("\n");
+        sb.append("    _configuration: ").append(toIndentedString(_configuration)).append("\n");
+        sb.append("    deploymentProcessId: ").append(toIndentedString(deploymentProcessId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+}
+

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppSpecConfiguration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppSpecConfiguration.java
@@ -50,7 +50,8 @@ import java.util.Objects;
 public class WebAppSpecConfiguration {
     private String kind;
     private String id;
-    private Map<String, String> values = null;
+    private Map<String, String> values;
+    private Map<String, String> defaultValues;
 
 
     public WebAppSpecConfiguration kind(String kind) {
@@ -67,7 +68,6 @@ public class WebAppSpecConfiguration {
     public void setKind(String kind) {
         this.kind = kind;
     }
-
 
     public WebAppSpecConfiguration id(String id) {
 
@@ -109,6 +109,15 @@ public class WebAppSpecConfiguration {
     }
 
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getDefaultValues() {
+        return defaultValues;
+    }
+
+    public void setDefaultValues(Map<String, String> defaultValues) {
+        this.defaultValues = defaultValues;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -120,12 +129,13 @@ public class WebAppSpecConfiguration {
         WebAppSpecConfiguration webAppSpecConfiguration = (WebAppSpecConfiguration) o;
         return Objects.equals(this.kind, webAppSpecConfiguration.kind) &&
                 Objects.equals(this.id, webAppSpecConfiguration.id) &&
-                Objects.equals(this.values, webAppSpecConfiguration.values);
+                Objects.equals(this.values, webAppSpecConfiguration.values) &&
+                Objects.equals(this.defaultValues, webAppSpecConfiguration.defaultValues);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kind, id, values);
+        return Objects.hash(kind, id);
     }
 
 

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppSpecConfiguration.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppSpecConfiguration.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * WebAppSpecConfiguration
+ */
+public class WebAppSpecConfiguration {
+    private String kind;
+    private String id;
+    private Map<String, String> values = null;
+
+
+    public WebAppSpecConfiguration kind(String kind) {
+
+        this.kind = kind;
+        return this;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+
+    public WebAppSpecConfiguration id(String id) {
+
+        this.id = id;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+
+    public WebAppSpecConfiguration values(Map<String, String> values) {
+        this.values = values;
+        return this;
+    }
+
+    public WebAppSpecConfiguration putValuesItem(String key, String valuesItem) {
+        if (this.values == null) {
+            this.values = new HashMap<>();
+        }
+        this.values.put(key, valuesItem);
+        return this;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getValues() {
+        return values;
+    }
+
+
+    public void setValues(Map<String, String> values) {
+        this.values = values;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WebAppSpecConfiguration webAppSpecConfiguration = (WebAppSpecConfiguration) o;
+        return Objects.equals(this.kind, webAppSpecConfiguration.kind) &&
+                Objects.equals(this.id, webAppSpecConfiguration.id) &&
+                Objects.equals(this.values, webAppSpecConfiguration.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, id, values);
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class WebAppSpecConfiguration {\n");
+        sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    values: ").append(toIndentedString(values)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+}
+

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppStatus.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppStatus.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * WebAppStatus
+ */
+@javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2020-03-23T19:23:58.881+01:00[Europe/Prague]")
+public class WebAppStatus {
+    private Long observedGeneration;
+
+    private URI publicEndpoint;
+
+    private List<WebAppStatusConditions> conditions = null;
+
+
+    public WebAppStatus observedGeneration(Long observedGeneration) {
+
+        this.observedGeneration = observedGeneration;
+        return this;
+    }
+
+    public Long getObservedGeneration() {
+        return observedGeneration;
+    }
+
+
+    public void setObservedGeneration(Long observedGeneration) {
+        this.observedGeneration = observedGeneration;
+    }
+
+
+    public WebAppStatus publicEndpoint(URI publicEndpoint) {
+
+        this.publicEndpoint = publicEndpoint;
+        return this;
+    }
+
+    public URI getPublicEndpoint() {
+        return publicEndpoint;
+    }
+
+
+    public void setPublicEndpoint(URI publicEndpoint) {
+        this.publicEndpoint = publicEndpoint;
+    }
+
+    public WebAppStatus conditions(List<WebAppStatusConditions> conditions) {
+
+        this.conditions = conditions;
+        return this;
+    }
+
+    public WebAppStatus addConditionsItem(WebAppStatusConditions conditionsItem) {
+        if (this.conditions == null) {
+            this.conditions = new ArrayList<>();
+        }
+        this.conditions.add(conditionsItem);
+        return this;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<WebAppStatusConditions> getConditions() {
+        return conditions;
+    }
+
+
+    public void setConditions(List<WebAppStatusConditions> conditions) {
+        this.conditions = conditions;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WebAppStatus webAppStatus = (WebAppStatus) o;
+        return Objects.equals(this.observedGeneration, webAppStatus.observedGeneration) &&
+                Objects.equals(this.publicEndpoint, webAppStatus.publicEndpoint) &&
+                Objects.equals(this.conditions, webAppStatus.conditions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(observedGeneration, publicEndpoint, conditions);
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class WebAppStatus {\n");
+        sb.append("    observedGeneration: ").append(toIndentedString(observedGeneration)).append("\n");
+        sb.append("    publicEndpoint: ").append(toIndentedString(publicEndpoint)).append("\n");
+        sb.append("    conditions: ").append(toIndentedString(conditions)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+}
+

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppStatusConditions.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/crd/WebAppStatusConditions.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes.crd;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+@javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2020-03-23T19:23:58.881+01:00[Europe/Prague]")
+public class WebAppStatusConditions {
+    private String type;
+    private StatusEnum status;
+    private String reason;
+    private String message;
+    private OffsetDateTime lastUpdateTime;
+
+    public WebAppStatusConditions type(String type) {
+
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     **/
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public WebAppStatusConditions status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    public WebAppStatusConditions reason(String reason) {
+
+        this.reason = reason;
+        return this;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public WebAppStatusConditions message(String message) {
+
+        this.message = message;
+        return this;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public WebAppStatusConditions lastUpdateTime(OffsetDateTime lastUpdateTime) {
+
+        this.lastUpdateTime = lastUpdateTime;
+        return this;
+    }
+
+    public OffsetDateTime getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(OffsetDateTime lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WebAppStatusConditions webAppStatusConditions = (WebAppStatusConditions) o;
+        return Objects.equals(this.type, webAppStatusConditions.type) &&
+                Objects.equals(this.status, webAppStatusConditions.status) &&
+                Objects.equals(this.reason, webAppStatusConditions.reason) &&
+                Objects.equals(this.message, webAppStatusConditions.message) &&
+                Objects.equals(this.lastUpdateTime, webAppStatusConditions.lastUpdateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, status, reason, message, lastUpdateTime);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class WebAppStatusConditions {\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    lastUpdateTime: ").append(toIndentedString(lastUpdateTime)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+    /**
+     * Gets or Sets status
+     */
+    public enum StatusEnum {
+        TRUE("true"),
+
+        FALSE("false"),
+
+        UNKNOWN("Unknown");
+
+        private String value;
+
+        StatusEnum(String value) {
+            this.value = value;
+        }
+
+        @JsonCreator
+        public static StatusEnum fromValue(String value) {
+            for (StatusEnum b : StatusEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
+
+}
+

--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/MockProvisioner.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/provisioning/MockProvisioner.java
@@ -103,6 +103,6 @@ class MockProvisioner implements Provisioner {
 
     @Override
     public List<DeploymentInfo> getDeploymentsWithIngress(Namespace namespace) {
-        return List.of(new DeploymentInfo(namespace, UUID.randomUUID().toString(), "foo").addUrl("http://www.example/com"));
+        return List.of(new DeploymentInfo(namespace, UUID.randomUUID().toString(), "foo").addUrl("http://www.example.com"));
     }
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/ArquillianDeployments.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/ArquillianDeployments.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer;
+
+import fish.payara.cloud.deployer.artifactstorage.ArtifactStorage;
+import fish.payara.cloud.deployer.artifactstorage.TempArtifactStorage;
+import fish.payara.cloud.deployer.endpoints.Application;
+import fish.payara.cloud.deployer.inspection.Inspection;
+import fish.payara.cloud.deployer.inspection.contextroot.ContextRootConfiguration;
+import fish.payara.cloud.deployer.inspection.datasource.DatasourceConfiguration;
+import fish.payara.cloud.deployer.inspection.mpconfig.MicroprofileConfiguration;
+import fish.payara.cloud.deployer.process.ChangeKind;
+import fish.payara.cloud.deployer.process.Configuration;
+import fish.payara.cloud.deployer.process.DeploymentProcess;
+import fish.payara.cloud.deployer.process.DeploymentProcessLogOutput;
+import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.process.Namespace;
+import fish.payara.cloud.deployer.process.ProcessAccessor;
+import fish.payara.cloud.deployer.process.StateChanged;
+import fish.payara.cloud.deployer.provisioning.Provisioner;
+import fish.payara.cloud.deployer.setup.SetupExtension;
+import fish.payara.cloud.deployer.utils.DurationConverter;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import javax.enterprise.inject.spi.Extension;
+import javax.mvc.Models;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Properties;
+
+public class ArquillianDeployments {
+    public interface Composition {
+        WebArchive apply(WebArchive source);
+    }
+
+    public static WebArchive compose(Composition... parts) {
+        var archive = ShrinkWrap.create(WebArchive.class);
+        return compose(archive, parts);
+    }
+
+    private static WebArchive compose(WebArchive archive, Composition... parts) {
+        for (Composition part : parts) {
+            archive = part.apply(archive);
+        }
+        return archive;
+    }
+
+    public static Composition azureStorage() {
+        var shrinkwrap = Maven.resolver().loadPomFromFile("pom.xml").resolve("com.microsoft.azure:azure-storage")
+                .withTransitivity().asFile();
+        return a -> a.addAsLibraries(shrinkwrap)
+                .addClass(ArtifactStorage.class)
+                .addClass("fish.payara.cloud.deployer.artifactstorage.AzureBlobStorage");
+    }
+
+    public static Composition mpConfig(Map<String,String> properties) {
+        var props = new Properties();
+        props.putAll(properties);
+        var writer = new StringWriter();
+        try {
+            props.store(writer, null);
+        } catch (IOException e) {
+            throw new IllegalStateException("Impossible!", e);
+        }
+        return a -> a.addAsResource(new StringAsset(writer.toString()), "META-INF/microprofile-config.properties");
+    }
+
+    public static Composition deploymentProcessModel() {
+        return a -> a.addClasses(DeploymentProcessState.class,
+                Namespace.class,
+                ChangeKind.class,
+                StateChanged.class,
+                DeploymentProcessLogOutput.class,
+                Configuration.class,
+                ProcessAccessor.class);
+    }
+
+    public static Composition setupExtension() {
+        return a -> a.addAsServiceProvider(Extension.class, SetupExtension.class);
+    }
+
+    public static Composition deploymentProcess() {
+        return a -> a.addPackage(DeploymentProcess.class.getPackage());
+    }
+
+    public static Composition utils() {
+        return a -> a.addAsServiceProvider(Converter.class, DurationConverter.class)
+                    .addPackage(DurationConverter.class.getPackage());
+    }
+
+    public static Composition inspection() {
+        return a -> compose(a, deploymentProcess(), utils())
+                        .addPackage(Inspection.class.getPackage())
+                        .addPackage(ContextRootConfiguration.class.getPackage())
+                        .addPackage(DatasourceConfiguration.class.getPackage())
+                        .addPackage(MicroprofileConfiguration.class.getPackage());
+    }
+
+    public static Composition shrinkwrap() {
+        var shrinkwrap = Maven.resolver().loadPomFromFile("pom.xml").resolve("org.jboss.shrinkwrap:shrinkwrap-impl-base")
+                .withTransitivity().asFile();
+        return a -> a.addAsLibraries(shrinkwrap);
+    }
+
+    public static Composition provisioning() {
+        return a -> compose(a, deploymentProcess(), utils()).addPackage(Provisioner.class.getPackage())
+                .addClass(ArtifactStorage.class)
+                .addClass(TempArtifactStorage.class);
+    }
+
+    public static Composition configuration() {
+        return a -> compose(a, deploymentProcess(), inspection())
+                .addPackage("fish.payara.cloud.deployer.configuration");
+    }
+
+    public static Composition restApi() {
+        return a -> compose(a, deploymentProcess(), inspection(), provisioning(), configuration())
+                .addPackage(Application.class.getPackage())
+                .addClass(Models.class);
+    }
+
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/ArquillianDeployments.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/ArquillianDeployments.java
@@ -50,6 +50,7 @@ import fish.payara.cloud.deployer.process.Configuration;
 import fish.payara.cloud.deployer.process.DeploymentProcess;
 import fish.payara.cloud.deployer.process.DeploymentProcessLogOutput;
 import fish.payara.cloud.deployer.process.DeploymentProcessState;
+import fish.payara.cloud.deployer.process.LogProduced;
 import fish.payara.cloud.deployer.process.Namespace;
 import fish.payara.cloud.deployer.process.ProcessAccessor;
 import fish.payara.cloud.deployer.process.StateChanged;
@@ -113,6 +114,7 @@ public class ArquillianDeployments {
                 StateChanged.class,
                 DeploymentProcessLogOutput.class,
                 Configuration.class,
+                LogProduced.class,
                 ProcessAccessor.class);
     }
 

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/configuration/ConfigurationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/configuration/ConfigurationIT.java
@@ -62,6 +62,7 @@ import javax.inject.Inject;
 
 import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
 import static fish.payara.cloud.deployer.ArquillianDeployments.configuration;
+import static fish.payara.cloud.deployer.ArquillianDeployments.shrinkwrap;
 import static fish.payara.cloud.deployer.inspection.InspectionHelper.write;
 import fish.payara.cloud.deployer.provisioning.Provisioner;
 
@@ -70,7 +71,7 @@ public class ConfigurationIT {
 
     @Deployment
     public static WebArchive createDeployment() {
-        return compose(configuration());
+        return compose(shrinkwrap(), configuration());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/configuration/ConfigurationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/configuration/ConfigurationIT.java
@@ -60,6 +60,8 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.configuration;
 import static fish.payara.cloud.deployer.inspection.InspectionHelper.write;
 import fish.payara.cloud.deployer.provisioning.Provisioner;
 
@@ -68,18 +70,7 @@ public class ConfigurationIT {
 
     @Deployment
     public static WebArchive createDeployment() {
-        var shrinkwrap = Maven.resolver().loadPomFromFile("pom.xml").resolve("org.jboss.shrinkwrap:shrinkwrap-impl-base")
-                .withTransitivity().asFile();
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addPackage(Inspection.class.getPackage())
-                .addPackage(ContextRootConfiguration.class.getPackage())
-                .addPackage(Provisioner.class.getPackage())
-                .addClass(DurationConverter.class)
-                .addClass(ManagedConcurrencyProducer.class)
-                .addClass(InspectionObserver.class)
-                .addClass(ConfigurationController.class)
-                .addAsLibraries(shrinkwrap);
+        return compose(configuration());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/ConfigurationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/ConfigurationIT.java
@@ -59,6 +59,8 @@ import javax.ws.rs.core.MediaType;
 import java.net.URI;
 import java.util.Map;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.restApi;
 import static fish.payara.cloud.deployer.inspection.contextroot.ContextRootConfiguration.APP_NAME;
 import static fish.payara.cloud.deployer.inspection.contextroot.ContextRootConfiguration.CONTEXT_ROOT;
 import static fish.payara.cloud.deployer.inspection.contextroot.ContextRootConfiguration.KIND;
@@ -74,14 +76,7 @@ import static org.junit.Assert.assertTrue;
 public class ConfigurationIT {
     @Deployment
     public static WebArchive deployment() {
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addPackage(Application.class.getPackage())
-                .addPackage(Provisioner.class.getPackage())
-                .addClass(ContextRootConfiguration.class)
-                .addClass(ManagedConcurrencyProducer.class)
-                .addClass(Models.class)
-                .addClass(ModelsImpl.class);
+        return compose(restApi());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/NamespaceIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/NamespaceIT.java
@@ -44,6 +44,7 @@ package fish.payara.cloud.deployer.endpoints;
 
 import fish.payara.cloud.deployer.inspection.contextroot.ContextRootConfiguration;
 import fish.payara.cloud.deployer.process.DeploymentProcess;
+import fish.payara.cloud.deployer.provisioning.DeploymentInfo;
 import fish.payara.cloud.deployer.provisioning.Provisioner;
 import fish.payara.cloud.deployer.utils.ManagedConcurrencyProducer;
 import java.net.URI;
@@ -54,6 +55,7 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.mvc.Models;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import org.junit.Assert;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -98,11 +100,10 @@ public class NamespaceIT {
     @Test
     public void testDeploymentsList() {
         var client = ClientBuilder.newClient().target(uri).path("api/namespaces/bar/foo");
-        var response = client.request(MediaType.APPLICATION_JSON).get(Map.class);
+        var response = client.request(MediaType.APPLICATION_JSON).get(JsonArray.class);
         Assert.assertEquals(1, response.size());
-        List array = (List) response.get("foo");
-        Assert.assertEquals(1, array.size());
-        Assert.assertEquals("http://www.example.com", array.get(0).toString());
+        var deployment = response.get(0);
+        Assert.assertEquals("http://www.example.com", deployment.asJsonObject().getJsonArray("urls").getString(0));
     }
     
 }

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/NamespaceIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/NamespaceIT.java
@@ -64,6 +64,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.restApi;
+
 /**
  * Test for the namespaces endpoint
  * @author jonathan coustick
@@ -73,14 +76,7 @@ public class NamespaceIT {
     
     @Deployment
     public static WebArchive deployment() {
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addPackage(Application.class.getPackage())
-                .addPackage(Provisioner.class.getPackage())
-                .addClass(ContextRootConfiguration.class)
-                .addClass(ManagedConcurrencyProducer.class)
-                .addClass(Models.class)
-                .addClass(ModelsImpl.class);
+        return compose(restApi());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/ServerSideEventsIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/ServerSideEventsIT.java
@@ -71,6 +71,8 @@ import java.util.logging.Logger;
 import javax.enterprise.context.RequestScoped;
 import javax.mvc.Models;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.restApi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -81,13 +83,7 @@ public class ServerSideEventsIT {
 
     @Deployment
     public static WebArchive deployment() {
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addPackage(Provisioner.class.getPackage())
-                .addPackage(Application.class.getPackage())
-                .addClass(ManagedConcurrencyProducer.class)
-                .addClass(Models.class)
-                .addClass(ModelsImpl.class);
+        return compose(restApi());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/UploadIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/endpoints/UploadIT.java
@@ -65,6 +65,9 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.restApi;
+
 /**
  * Tests that the deployment endpoint works
  * @author jonathan coustick
@@ -74,16 +77,7 @@ public class UploadIT {
     
     @Deployment
     public static WebArchive deployment() {
-        WebArchive archive =  ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addPackage(Provisioner.class.getPackage())
-                .addPackage(Application.class.getPackage())
-                .addClass(ManagedConcurrencyProducer.class)
-                .addClass(Models.class)
-                .addClass(ModelsImpl.class);
-
-        System.out.println(archive.toString(true));
-        return archive;
+        return compose(restApi());
     }
     
     @ArquillianResource

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/inspection/InspectionIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/inspection/InspectionIT.java
@@ -55,6 +55,10 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.inspection;
+import static fish.payara.cloud.deployer.ArquillianDeployments.restApi;
+import static fish.payara.cloud.deployer.ArquillianDeployments.shrinkwrap;
 import static fish.payara.cloud.deployer.inspection.InspectionHelper.write;
 import static org.junit.Assert.assertEquals;
 
@@ -62,16 +66,7 @@ import static org.junit.Assert.assertEquals;
 public class InspectionIT {
     @Deployment
     public static WebArchive deployment() {
-        var shrinkwrap = Maven.resolver().loadPomFromFile("pom.xml").resolve("org.jboss.shrinkwrap:shrinkwrap-impl-base")
-                .withTransitivity().asFile();
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addPackage(Inspection.class.getPackage())
-                .addPackage(ContextRootConfiguration.class.getPackage())
-                .addClass(DurationConverter.class)
-                .addClass(ManagedConcurrencyProducer.class)
-                .addClass(InspectionObserver.class)
-                .addAsLibraries(shrinkwrap);
+        return compose(shrinkwrap(), inspection());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/CrdTestManual.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/CrdTestManual.java
@@ -180,11 +180,14 @@ public class CrdTestManual {
         config.setKind("contextRoot");
         config.setId("whatever.war");
         config.setValues(Map.of("key1", "value1", "key 2", "value 3", "emptyKey", ""));
+        config.setDefaultValues(Map.of("key1", "value12", "key 2", "value 33", "emptyKey", ""));
+        resource.getSpec().addConfigurationItem(config);
         resource.getSpec().addConfigurationItem(config);
         crClient.create(resource);
 
         var read = readFromServer(resource);
         assertEquals(config.getValues(), read.getSpec().getConfiguration().get(0).getValues());
+        assertEquals(config.getDefaultValues(), read.getSpec().getConfiguration().get(0).getDefaultValues());
     }
 
     @Test

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/CrdTestManual.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/kubernetes/CrdTestManual.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ */
+
+package fish.payara.cloud.deployer.kubernetes;
+
+import fish.payara.cloud.deployer.kubernetes.crd.WebAppCustomResource;
+import fish.payara.cloud.deployer.kubernetes.crd.WebAppSpecConfiguration;
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.internal.KubernetesDeserializer;
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+
+import static fish.payara.cloud.deployer.kubernetes.crd.WebAppCustomResource.CRD_GROUP;
+import static fish.payara.cloud.deployer.kubernetes.crd.WebAppCustomResource.VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CrdTestManual {
+    public static final String TEST_KIND = "WebappTestCrd";
+    private static NamespacedKubernetesClient client;
+    private static Namespace testNamespace;
+    private static CustomResourceDefinition resourceDefinition;
+    private static MixedOperation<TestResource, TestResourceList, DoneableResource, Resource<TestResource, DoneableResource>> crClient;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public TestName name = new TestName();
+    private TestResource resource;
+
+    @BeforeClass
+    public static void prepareCluster() {
+        // connect
+        var appClient = new KubernetesClient();
+        appClient.connectApiServer();
+        client = appClient.client;
+
+        // create namespace
+        testNamespace = new Namespace();
+        testNamespace.setMetadata(new ObjectMeta());
+        testNamespace.getMetadata().setName("crd-test");
+        testNamespace = appClient.client.namespaces().createOrReplace(testNamespace);
+        client = client.inNamespace("crd-test");
+
+        // create test CRD by modifying names of original one
+        resourceDefinition = client.customResourceDefinitions().load("../../install/webapp-crd.yaml").get();
+
+        resourceDefinition.getMetadata().setName("webapp-test-crds."+ CRD_GROUP);
+        var names = resourceDefinition.getSpec().getNames();
+        names.setKind(TEST_KIND);
+        names.setSingular("webapp-test-crd");
+        names.setPlural("webapp-test-crds");
+
+        resourceDefinition = client.customResourceDefinitions().create(resourceDefinition);
+
+        // register deserialization data
+        KubernetesDeserializer.registerCustomKind(CRD_GROUP + "/" + VERSION, TEST_KIND, TestResource.class);
+
+        crClient = client.customResources(resourceDefinition, TestResource.class, TestResourceList.class, DoneableResource.class);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        if (resourceDefinition != null) {
+            client.customResourceDefinitions().delete(resourceDefinition);
+        }
+        if (testNamespace != null) {
+            client.namespaces().delete(testNamespace);
+        }
+        client.close();
+    }
+
+    @Before
+    public void prepareResource() {
+        resource = new TestResource(name.getMethodName()
+                .replaceAll("([a-z])([A-Z])","$1-$2").toLowerCase());
+        resource.getSpec().setArtifactUrl(URI.create("https://"+name.getMethodName()));
+    }
+
+    @Test
+    public void emptySpecFails() {
+        resource.setSpec(null);
+        exception.expectMessage("spec in body is required");
+        crClient.create(resource);
+    }
+
+    @Test
+    public void minimalResourcePasses() {
+        crClient.create(resource);
+
+        var read = readFromServer(resource);
+        assertEquals(resource.getSpec().getArtifactUrl(), read.getSpec().getArtifactUrl());
+    }
+
+    @Test
+    public void optionalFieldsCanBeSpecified() {
+        resource.getSpec().setDeploymentProcessId(UUID.randomUUID());
+
+        crClient.create(resource);
+        var read = readFromServer(resource);
+        assertEquals(resource.getSpec().getDeploymentProcessId(), resource.getSpec().getDeploymentProcessId());
+    }
+
+    @Test
+    public void incompleteConfigRejected() {
+        resource.getSpec().addConfigurationItem(new WebAppSpecConfiguration());
+        exception.expectMessage("configuration.id in body must be of type string");
+        exception.expectMessage("configuration.kind in body must be of type string");
+        crClient.create(resource);
+    }
+
+    @Test
+    public void emptyConfigAccepted() {
+        var config = new WebAppSpecConfiguration();
+        config.setKind("contextRoot");
+        config.setId("whatever.war");
+        resource.getSpec().addConfigurationItem(config);
+        crClient.create(resource);
+    }
+
+    @Test
+    public void nonEmptyConfigAccepted() {
+        var config = new WebAppSpecConfiguration();
+        config.setKind("contextRoot");
+        config.setId("whatever.war");
+        config.setValues(Map.of("key1", "value1", "key 2", "value 3", "emptyKey", ""));
+        resource.getSpec().addConfigurationItem(config);
+        crClient.create(resource);
+
+        var read = readFromServer(resource);
+        assertEquals(config.getValues(), read.getSpec().getConfiguration().get(0).getValues());
+    }
+
+    @Test
+    // doesn't seem to work with K8s 1.14
+    @Ignore
+    public void spaceInConfigKindRejected() {
+        var config = new WebAppSpecConfiguration();
+        config.setKind("context root");
+        config.setId("whatever.war");
+        resource.getSpec().addConfigurationItem(config);
+        exception.expectMessage(".kind");
+    }
+
+    @Test
+    public void colonInIdAccepted() {
+        var config = new WebAppSpecConfiguration();
+        config.setKind("contextRoot");
+        config.setId("colons:accepted:except:for:double:");
+        resource.getSpec().addConfigurationItem(config);
+        crClient.create(resource);
+    }
+
+    @Test
+    // doesn't seem to work with K8s 1.14
+    @Ignore
+    public void doublecolonInIdRejected() {
+        var config = new WebAppSpecConfiguration();
+        config.setKind("contextRoot");
+        config.setId("reject::this");
+        resource.getSpec().addConfigurationItem(config);
+        crClient.create(resource);
+        exception.expectMessage(".id");
+    }
+
+    @Test
+    public void updatingStatusPreservesGeneration() {
+        crClient.create(resource);
+
+        var read1 = readFromServer(resource);
+        assertNotNull(read1.getMetadata().getGeneration());
+
+        read1.makeStatus().setPublicEndpoint(URI.create("https://google.com"));
+        crClient.updateStatus(read1);
+        var read2 = readFromServer(read1);
+        assertEquals(read1.getMetadata().getGeneration(), read2.getMetadata().getGeneration());
+        assertEquals(read1.getMetadata().getGeneration(), read2.getStatus().getObservedGeneration());
+        assertEquals(read1.getStatus().getPublicEndpoint(), read2.getStatus().getPublicEndpoint());
+    }
+
+    @Test
+    public void updatingSpecUpdatesGeneration() {
+        resource.getSpec().addConfigurationItem("config", "id", Map.of("key", "value"));
+        crClient.create(resource);
+
+        var read1 = readFromServer(resource);
+        assertNotNull(read1.getMetadata().getGeneration());
+        var sourceGeneration = read1.getMetadata().getGeneration();
+
+        read1.getSpec().getConfiguration().get(0).getValues().put("key", "value2");
+        crClient.withName(read1.getMetadata().getName()).patch(read1);
+        var read2 = readFromServer(read1);
+
+        assertThat(read2.getMetadata().getGeneration()).isGreaterThan(read1.getMetadata().getGeneration());
+    }
+
+    private TestResource readFromServer(TestResource simpleApp) {
+        return crClient.withName(simpleApp.getMetadata().getName()).fromServer().get();
+    }
+
+    // Helper types
+
+    public static class TestResource extends WebAppCustomResource {
+        public TestResource() {
+            super("WebappTestCrd");
+        }
+
+        public TestResource(String name) {
+            this();
+            getMetadata().setName(name);
+        }
+    }
+
+    public static class TestResourceList extends CustomResourceList<TestResource> {}
+
+    public static class DoneableResource extends CustomResourceDoneable<TestResource> {
+        public DoneableResource(TestResource resource, Function<TestResource, TestResource> function) {
+            super(resource, function);
+        }
+    }
+}

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/DeploymentObservationIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/process/DeploymentObservationIT.java
@@ -48,6 +48,8 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.deploymentProcess;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -58,9 +60,7 @@ import static org.junit.Assert.assertTrue;
 public class DeploymentObservationIT {
     @Deployment
     public static WebArchive deployment() {
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addClass(ProcessObserver.class);
+        return compose(deploymentProcess());
     }
 
     @Inject

--- a/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionTimeoutIT.java
+++ b/deployer/deployment-controller/src/test/java/fish/payara/cloud/deployer/provisioning/ProvisionTimeoutIT.java
@@ -56,19 +56,17 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Map;
+
+import static fish.payara.cloud.deployer.ArquillianDeployments.compose;
+import static fish.payara.cloud.deployer.ArquillianDeployments.mpConfig;
+import static fish.payara.cloud.deployer.ArquillianDeployments.provisioning;
 
 @RunWith(Arquillian.class)
 public class ProvisionTimeoutIT {
     @Deployment
     public static WebArchive deployment() {
-        return ShrinkWrap.create(WebArchive.class)
-                .addPackage(DeploymentProcess.class.getPackage())
-                .addClass(ProcessObserver.class)
-                .addPackage(ProvisioningController.class.getPackage())
-                .addClass(ArtifactStorage.class)
-                .addClass(TempArtifactStorage.class)
-                .addClass(ManagedConcurrencyProducer.class)
-                .addAsResource(new StringAsset("provisioning.timeout=PT2S"), "META-INF/microprofile-config.properties");
+        return compose(provisioning(), mpConfig(Map.of("provisioning.timeout","PT2S")));
     }
 
     @Inject

--- a/install/webapp-crd.yaml
+++ b/install/webapp-crd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: webapps.payara.cloud
+spec:
+  group: payara.cloud
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: webapps
+    # singular name to be used as an alias on the CLI and for display
+    singular: webapp
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: WebApp
+  subresources:
+    status: {}
+  versions:
+    - name: v1beta1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+  validation:
+    openAPIV3Schema: # keep in sync with ../deployer/deployment-controller/src/main/schema/crd-schema.yaml#components/schemas/WebApp
+      required:
+        - spec
+      properties:
+        spec:
+          type: object
+          required:
+            - artifactUrl
+          properties:
+            # name is part of standard metadata
+            # id is part of standard metadata (uid)
+            # namespace is determined by kubernetes namespace of the object
+            artifactUrl:
+              type: string
+              format: uri
+              description: "The URL of stored artifact"
+              nullable: false
+            # artifact: will be specified if we need more structure
+
+            configuration:
+              description: "Set of configurations of an artifact"
+              type: array
+              items:
+                type: object
+                required:
+                  - kind
+                  - id
+                properties:
+                  kind:
+                    type: string
+                    pattern: '\w+'
+                    nullable: false
+                  id:
+                    type: string
+                    pattern: '\w([^\s:]|:([^:]|$))+' # anything without spaces and double colon
+                    nullable: false
+                  values:
+                    type: object
+                    additionalProperties:
+                      type: string
+            deploymentProcessId:
+              # even though kubernetes assignes own ID, some parts of the process already depend on generated ID
+              # so we keep this for reference. Entries created via Kubernetes API do not need to specify this.
+              type: string
+              format: UUID
+        status:
+          type: object
+          properties:
+            # we just learn from deployment status and figure this out as we write controller
+            observedGeneration:
+              type: integer
+            publicEndpoint:
+              type: string
+              format: uri
+            conditions: # condition per https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+              type: array
+              items:
+                type: object
+                required:
+                  - type
+                  - status
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                    enum: [True, False, Unknown]
+                  reason:
+                    type: string
+                  message:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                    format: date-time
+

--- a/install/webapp-crd.yaml
+++ b/install/webapp-crd.yaml
@@ -62,6 +62,10 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  defaultValues:
+                    type: object
+                    additionalProperties:
+                      type: string
             deploymentProcessId:
               # even though kubernetes assignes own ID, some parts of the process already depend on generated ID
               # so we keep this for reference. Entries created via Kubernetes API do not need to specify this.

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <properties>
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <payara.version>5.201-SNAPSHOT</payara.version>
+        <payara.version>5.201</payara.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Added resource definition, jackson mapping and client support for working with the new resource type.

CrdTestManual could be actually run automatically against kubernetesc cluster, as it creates its own CRD to verify validations against.

The mapping classes were originally generated from OpenAPI definition, but it required manual adjustments, and the definition had to be manually synchronized with CRD definition anyway, so it's easier to maintain set of tests to run against cluster instead.