### PR TITLE
Fix cloud instance's lookup of config files in mounted Kubernetes ConfigMaps

### DIFF
--- a/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/KubernetesWatcher.java
+++ b/deployer/deployment-controller/src/main/java/fish/payara/cloud/deployer/kubernetes/KubernetesWatcher.java
@@ -41,6 +41,7 @@ package fish.payara.cloud.deployer.kubernetes;
 import fish.payara.cloud.deployer.process.ChangeKind;
 import fish.payara.cloud.deployer.process.DeploymentProcess;
 import fish.payara.cloud.deployer.process.StateChanged;
+import fish.payara.cloud.deployer.setup.CloudInstanceProvisioning;
 import fish.payara.cloud.deployer.setup.DirectProvisioning;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -83,6 +84,7 @@ import java.util.regex.Pattern;
  */
 @ApplicationScoped
 @DirectProvisioning
+@CloudInstanceProvisioning
 class KubernetesWatcher implements Closeable {
     private static final Logger LOGGER = Logger.getLogger(KubernetesWatcher.class.getName());
 


### PR DESCRIPTION
Skips dotted files, and it's not easy to get Path API right at first take, therefore added a test as well.

Also enabled KubernetesWatcher when deploying cloud instances instead of Direct endpoints.